### PR TITLE
Fix scope usage

### DIFF
--- a/Client/OAuth2Client.php
+++ b/Client/OAuth2Client.php
@@ -45,7 +45,7 @@ class OAuth2Client
     {
         $options = array();
         if (!empty($scopes)) {
-            $options['scopes'] = $scopes;
+            $options['scope'] = $scopes;
         }
 
         $url = $this->provider->getAuthorizationUrl($options);

--- a/Tests/Client/OAuth2ClientTest.php
+++ b/Tests/Client/OAuth2ClientTest.php
@@ -28,7 +28,7 @@ class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testRedirectWithState()
     {
-        $this->provider->getAuthorizationUrl(['scopes' => ['scope1', 'scope2']])
+        $this->provider->getAuthorizationUrl(['scope' => ['scope1', 'scope2']])
             ->willReturn('http://coolOAuthServer.com/authorize');
         $this->provider->getState()
             ->willReturn('SOME_RANDOM_STATE');


### PR DESCRIPTION
Hi,

This PR allow to use scope.

For now, `scopes` was send but it should be `scope`

I test it for github.
https://developer.github.com/v3/oauth/#response

Here documentation from other provider:

- https://developers.facebook.com/docs/reference/javascript/FB.login/v2.5
- https://developer.linkedin.com/docs/oauth2

What do you think ?