### PR TITLE
Use '^' instead of '~' for required package versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.4|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
-        "symfony/routing": "~2.3|~3.0",
-        "symfony/http-foundation": "~2.4|~3.0",
+        "symfony/framework-bundle": "^2.4|^3.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/routing": "^2.3|^3.0",
+        "symfony/http-foundation": "^2.4|^3.0",
         "league/oauth2-client": "^1.0"
     },
     "autoload": {
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1",
-        "symfony/security-guard": "~2.8|~3.0"
+        "symfony/security-guard": "^2.8|^3.0"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"


### PR DESCRIPTION
> The ^ operator behaves very similarly but it sticks closer to semantic versioning, and will always allow non-breaking updates.
