### PR TITLE
Dev dependencies should include the compatible PHPunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1",
-        "symfony/security-guard": "^2.8|^3.0"
+        "symfony/security-guard": "^2.8|^3.0",
+        "phpunit/phpunit": "^5.5",
+        "phpunit/php-code-coverage": "^4.0"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require-dev": {
         "league/oauth2-facebook": "^1.1",
         "symfony/security-guard": "^2.8|^3.0",
-        "phpunit/phpunit": "^5.5",
-        "phpunit/php-code-coverage": "^4.0"
+        "phpunit/phpunit": "^4.8",
+        "phpunit/php-code-coverage": "^2.2"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": " >=5.5.0",
+        "php": " >=5.5.9",
         "symfony/framework-bundle": "^2.4|^3.0",
         "symfony/dependency-injection": "^2.8|^3.0",
         "symfony/routing": "^2.3|^3.0",
@@ -25,8 +25,7 @@
     "require-dev": {
         "league/oauth2-facebook": "^1.1",
         "symfony/security-guard": "^2.8|^3.0",
-        "phpunit/phpunit": "^4.8",
-        "phpunit/php-code-coverage": "^2.2"
+        "phpunit/phpunit": "^4.8"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"


### PR DESCRIPTION
Added the correct `phpunit` and `php-code-coverage` dependencies so everyone can run the tests right out of the box after a fork.