### PR TITLE
Fix optional configuration in Google provider

### DIFF
--- a/src/DependencyInjection/Providers/GoogleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GoogleProviderConfigurator.php
@@ -19,9 +19,11 @@ class GoogleProviderConfigurator implements ProviderConfiguratorInterface
         // todo - add the comments as help text, and render in README
         $node
             ->scalarNode('access_type')
+                ->defaultValue('')
                 ->info('Optional value for sending access_type parameter. More detail: https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters')
             ->end()
             ->scalarNode('hosted_domain')
+                ->defaultValue('')
                 ->info('Optional value for sending hd parameter. More detail: https://developers.google.com/identity/protocols/OpenIDConnect#hd-param')
             ->end()
             ->arrayNode('user_fields')


### PR DESCRIPTION
Avoid notice `Undefined index: access_type` on [this line](https://github.com/knpuniversity/oauth2-client-bundle/tree/ad82b0f780e1ad54dd7de2d353027d8384891080/src/DependencyInjection/Providers/GoogleProviderConfigurator.php#L44) when optional configuration is not given