### PR TITLE
Update service definition for autowiring

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,6 +13,9 @@
             <argument type="service" id="service_container" />
             <argument /> <!-- argument added dynamically -->
         </service>
+	
+	<!-- Add service alias for autowiring -->
+	<service id="KnpU\OAuth2ClientBundle\Client\ClientRegistry" alias="knpu.oauth2.registry" public="false" />
 
         <!-- Set an alias for easier use -->
         <service id="oauth2.registry" alias="knpu.oauth2.registry" />


### PR DESCRIPTION
As of Symfony 3.3, autowire_types is deprecated.

This adds an alias for the knpu.oauth2.registry service definition.