### PR TITLE
Set an alias to every client service

### DIFF
--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -214,6 +214,8 @@ class KnpUOAuth2ClientExtension extends Extension
             $clientDefinition->addMethodCall('setAsStateless');
         }
 
+        $container->setAlias($clientClass, $clientServiceKey);
+
         return $clientServiceKey;
     }
 

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -221,7 +221,7 @@ class KnpUOAuth2ClientExtension extends Extension
         // add an alias, but only if a provider type is used only 1 time
         if (!in_array($providerType, $this->duplicateProviderTypes)) {
             // alias already exists? This is a duplicate type, record it
-            if ($container->getAlias($clientClass)) {
+            if ($container->hasAlias($clientClass)) {
                 $this->duplicateProviderTypes[] = $providerType;
             } else {
                 // all good, add the alias

--- a/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
+++ b/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
@@ -80,6 +80,12 @@ class KnpUOAuth2ClientExtensionTest extends \PHPUnit_Framework_TestCase
             ],
             $clientDefinition->getArguments()
         );
+
+        // the client service has an alias
+        $this->assertTrue(
+            $this->configuration->hasAlias('KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient'),
+            'FacebookClient service is missing an alias'
+        );
     }
 
     /**


### PR DESCRIPTION
Fix #60 

I feel like the _service Id_ and _alias name_ are inverted, but tests does not pass if I do it the other way around