### PR TITLE
Add simple user provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,28 @@ ciricular reference issues and degrades performance (because autheticators are i
 on every request, even though you *rarely* need the `FacebookClient` to be created).
 The `ClientRegistry` lazily creates the client objects.
 
+### Authenticating any OAuth user
+
+If you don't need to fetch/persist any information about the user, you can use the `OAuthUserProvider` service to quickly authenticate them into your application.
+
+Firstly define the user provider in your `security.yml` file:
+
+```yml
+security:
+    providers:
+        oauth:
+            id: knpu.oauth2.user_provider
+```
+
+Then in your Guard authenticator use the user provider to log the user in to your application:
+
+```php
+public function getUser($credentials, UserProviderInterface $userProvider) : UserInterface
+{
+    return $userProvider->loadUserByUsername($this->getClient()->fetchUserFromToken($credentials)->getId());
+}
+```
+
 ## Configuration
 
 Below is the configuration for *all* of the supported OAuth2 providers.

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,6 +13,8 @@
             <argument type="service" id="service_container" />
             <argument /> <!-- argument added dynamically -->
         </service>
+
+        <service id="knpu.oauth2.user_provider" class="KnpU\OAuth2ClientBundle\Security\User\OAuthUserProvider" public="false" />
 	
 	<!-- Add service alias for autowiring -->
 	<service id="KnpU\OAuth2ClientBundle\Client\ClientRegistry" alias="knpu.oauth2.registry" public="false" />

--- a/src/Security/User/OAuthUser.php
+++ b/src/Security/User/OAuthUser.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Security\User;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class OAuthUser implements UserInterface
+{
+    private $username;
+    private $roles;
+
+    public function __construct($username, array $roles)
+    {
+        $this->username = $username;
+        $this->roles = $roles;
+    }
+
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    public function getPassword()
+    {
+        return '';
+    }
+
+    public function getSalt()
+    {
+        return null;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function eraseCredentials()
+    {
+        // Do nothing.
+    }
+}

--- a/src/Security/User/OAuthUserProvider.php
+++ b/src/Security/User/OAuthUserProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Security\User;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class OAuthUserProvider implements UserProviderInterface
+{
+    private $roles;
+
+    public function __construct(array $roles = ['ROLE_USER', 'ROLE_OAUTH_USER'])
+    {
+        $this->roles = $roles;
+    }
+
+    public function loadUserByUsername($username)
+    {
+        return new OAuthUser($username, $this->roles);
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$user instanceof OAuthUser) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
+        }
+
+        return $this->loadUserByUsername($user->getUsername());
+    }
+
+    public function supportsClass($class)
+    {
+        return OAuthUser::class === $class;
+    }
+}

--- a/tests/Security/User/OAuthUserProviderTest.php
+++ b/tests/Security/User/OAuthUserProviderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Tests\Security\User;
+
+use KnpU\OAuth2ClientBundle\Security\User\OAuthUser;
+use KnpU\OAuth2ClientBundle\Security\User\OAuthUserProvider;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoadUserByUsername()
+    {
+        $userProvider = new OAuthUserProvider(['role 1', 'role 2']);
+
+        $expected = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertEquals($expected, $userProvider->loadUserByUsername('username'));
+    }
+
+    public function testRefreshUser()
+    {
+        $userProvider = new OAuthUserProvider(['role 1', 'role 2']);
+
+        $user = new OAuthUser('username', ['role 3']);
+        $expected = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertEquals($expected, $userProvider->refreshUser($user));
+    }
+
+    public function testRefreshOtherUser()
+    {
+        $userProvider = new OAuthUserProvider();
+
+        $this->setExpectedException(UnsupportedUserException::class);
+
+        $userProvider->refreshUser(new SomeUser());
+    }
+
+    /**
+     * @dataProvider supportsClassProvider
+     */
+    public function testSupportsClass($class, $supports)
+    {
+        $userProvider = new OAuthUserProvider();
+
+        $this->assertSame($supports, $userProvider->supportsClass($class));
+    }
+
+    public function supportsClassProvider()
+    {
+        yield 'OAuthUser' => [OAuthUser::class, true];
+        yield 'other user' => [SomeUser::class, false];
+    }
+}
+
+class SomeUser implements UserInterface
+{
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/tests/Security/User/OAuthUserProviderTest.php
+++ b/tests/Security/User/OAuthUserProviderTest.php
@@ -13,6 +13,7 @@ namespace KnpU\OAuth2ClientBundle\Tests\Security\User;
 use KnpU\OAuth2ClientBundle\Security\User\OAuthUser;
 use KnpU\OAuth2ClientBundle\Security\User\OAuthUserProvider;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
@@ -42,7 +43,7 @@ class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(UnsupportedUserException::class);
 
-        $userProvider->refreshUser(new SomeUser());
+        $userProvider->refreshUser($this->getMock(UserInterface::class));
     }
 
     /**
@@ -58,29 +59,6 @@ class OAuthUserProviderTest extends \PHPUnit_Framework_TestCase
     public function supportsClassProvider()
     {
         yield 'OAuthUser' => [OAuthUser::class, true];
-        yield 'other user' => [SomeUser::class, false];
-    }
-}
-
-class SomeUser implements UserInterface
-{
-    public function getRoles()
-    {
-    }
-
-    public function getPassword()
-    {
-    }
-
-    public function getSalt()
-    {
-    }
-
-    public function getUsername()
-    {
-    }
-
-    public function eraseCredentials()
-    {
+        yield 'other user' => [User::class, false];
     }
 }

--- a/tests/Security/User/OAuthUserTest.php
+++ b/tests/Security/User/OAuthUserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Tests\Security\User;
+
+use KnpU\OAuth2ClientBundle\Security\User\OAuthUser;
+
+class OAuthUserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRoles()
+    {
+        $user = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertSame(['role 1', 'role 2'], $user->getRoles());
+    }
+
+    public function testPassword()
+    {
+        $user = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertSame('', $user->getPassword());
+    }
+
+    public function testSalt()
+    {
+        $user = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertNull($user->getSalt());
+    }
+
+    public function testUsername()
+    {
+        $user = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertSame('username', $user->getUsername());
+    }
+}


### PR DESCRIPTION
This add a user provider that can be used for simple authentication use cases, allowing any successful OAuth to authenticate into your app without any persistence.

(This is similar to [the other bundle](https://github.com/hwi/HWIOAuthBundle/blob/8a97b6b2ba0be0064c9616a3cfc14c2c0d8a589b/Security/Core/User/OAuthUserProvider.php).)