### PR TITLE
Fix missing GitlabResourceOwner namespace use

### DIFF
--- a/src/Client/Provider/GitlabClient.php
+++ b/src/Client/Provider/GitlabClient.php
@@ -12,6 +12,7 @@ namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
+use Omines\OAuth2\Client\Provider\GitlabResourceOwner;
 
 /**
  * GitlabClient.


### PR DESCRIPTION
Note: You should use a tool like PHPStan to prevent this kind of issue. ;-)