### PR TITLE
Catching 2 other common authentication errors

### DIFF
--- a/src/Security/Authenticator/SocialAuthenticator.php
+++ b/src/Security/Authenticator/SocialAuthenticator.php
@@ -10,11 +10,15 @@
 
 namespace KnpU\OAuth2ClientBundle\Security\Authenticator;
 
+use KnpU\OAuth2ClientBundle\Exception\InvalidStateException;
+use KnpU\OAuth2ClientBundle\Security\Exception\IdentityProviderAuthenticationException;
+use KnpU\OAuth2ClientBundle\Security\Exception\InvalidStateAuthenticationException;
 use KnpU\OAuth2ClientBundle\Security\Exception\NoAuthCodeAuthenticationException;
 use KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException;
 use KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior;
 use KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper;
 use KnpU\OAuth2ClientBundle\Security\Helper\SaveAuthFailureMessage;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
@@ -31,6 +35,10 @@ abstract class SocialAuthenticator extends AbstractGuardAuthenticator
             return $client->getAccessToken();
         } catch (MissingAuthorizationCodeException $e) {
             throw new NoAuthCodeAuthenticationException();
+        } catch (IdentityProviderException $e) {
+            throw new IdentityProviderAuthenticationException($e);
+        } catch (InvalidStateException $e) {
+            throw new InvalidStateAuthenticationException($e);
         }
     }
 

--- a/src/Security/Exception/IdentityProviderAuthenticationException.php
+++ b/src/Security/Exception/IdentityProviderAuthenticationException.php
@@ -31,7 +31,7 @@ class IdentityProviderAuthenticationException extends AuthenticationException
     public function getMessageData()
     {
         return [
-            'error' => $this->getPrevious()->getMessage(),
+            '%error%' => $this->getPrevious()->getMessage(),
         ];
     }
 

--- a/src/Security/Exception/IdentityProviderAuthenticationException.php
+++ b/src/Security/Exception/IdentityProviderAuthenticationException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Security\Exception;
+
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Thrown if an IdentityProviderException occurs during authentication.
+ */
+class IdentityProviderAuthenticationException extends AuthenticationException
+{
+    public function __construct(IdentityProviderException $e)
+    {
+        parent::__construct($e->getMessage(), $e->getCode(), $e);
+    }
+
+    public function getMessageKey()
+    {
+        return 'Error fetching OAuth credentials: "%error%".';
+    }
+
+    public function getMessageData()
+    {
+        return [
+            'error' => $this->getPrevious()->getMessage(),
+        ];
+    }
+
+
+}

--- a/src/Security/Exception/InvalidStateAuthenticationException.php
+++ b/src/Security/Exception/InvalidStateAuthenticationException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Security\Exception;
+
+use KnpU\OAuth2ClientBundle\Exception\InvalidStateException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Thrown when an InvalidStateException is thrown during authentication.
+ */
+class InvalidStateAuthenticationException extends AuthenticationException
+{
+    public function __construct(InvalidStateException $e)
+    {
+        parent::__construct($e->getMessage(), $e->getCode(), $e);
+    }
+
+    public function getMessageKey()
+    {
+        return 'Invalid state parameter passed in callback URL.';
+    }
+}


### PR DESCRIPTION
Fixes #78 

The entire point of `fetchAccessToken()` is to help catch as many "normal" errors as possible and turn them into proper "AuthenticationException" situations with decent messages.