### PR TITLE
Change underlying library for discord because it's not compliant with oauth2-client v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ via Composer:
 | [Clever](https://github.com/schoolrunner/oauth2-clever)               | composer require schoolrunner/oauth2-clever         |
 | [DevianArt](https://github.com/SeinopSys/oauth2-deviantart)           | composer require seinopsys/oauth2-deviantart        |
 | [DigitalOcean](https://github.com/chrishemmings/oauth2-digitalocean)  | composer require chrishemmings/oauth2-digitalocean  |
-| [Discord](https://github.com/teamreflex/oauth2-discord)               | composer require team-reflex/oauth2-discord         |
+| [Discord](https://github.com/wohali/oauth2-discord-new)               | composer require team-reflex/oauth2-discord         |
 | [Dribbble](https://github.com/crewlabs/oauth2-dribbble)               | composer require crewlabs/oauth2-dribbble           |
 | [Dropbox](https://github.com/stevenmaguire/oauth2-dropbox)            | composer require stevenmaguire/oauth2-dropbox       |
 | [Drupal](https://github.com/chrishemmings/oauth2-drupal)              | composer require chrishemmings/oauth2-drupal        |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ via Composer:
 | [Clever](https://github.com/schoolrunner/oauth2-clever)               | composer require schoolrunner/oauth2-clever         |
 | [DevianArt](https://github.com/SeinopSys/oauth2-deviantart)           | composer require seinopsys/oauth2-deviantart        |
 | [DigitalOcean](https://github.com/chrishemmings/oauth2-digitalocean)  | composer require chrishemmings/oauth2-digitalocean  |
-| [Discord](https://github.com/wohali/oauth2-discord-new)               | composer require team-reflex/oauth2-discord         |
+| [Discord](https://github.com/wohali/oauth2-discord-new)               | composer require wohali/oauth2-discord-new         |
 | [Dribbble](https://github.com/crewlabs/oauth2-dribbble)               | composer require crewlabs/oauth2-dribbble           |
 | [Dropbox](https://github.com/stevenmaguire/oauth2-dropbox)            | composer require stevenmaguire/oauth2-dropbox       |
 | [Drupal](https://github.com/chrishemmings/oauth2-drupal)              | composer require chrishemmings/oauth2-drupal        |

--- a/src/Client/Provider/DiscordClient.php
+++ b/src/Client/Provider/DiscordClient.php
@@ -12,13 +12,13 @@ namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use Discord\OAuth\Parts\User;
+use Wohali\OAuth2\Client\Provider\DiscordResourceOwner;
 
 class DiscordClient extends OAuth2Client
 {
     /**
      * @param AccessToken $accessToken
-     * @return User
+     * @return DiscordResourceOwner
      */
     public function fetchUserFromToken(AccessToken $accessToken)
     {
@@ -26,7 +26,7 @@ class DiscordClient extends OAuth2Client
     }
 
     /**
-     * @return User
+     * @return DiscordResourceOwner
      */
     public function fetchUser()
     {

--- a/src/DependencyInjection/Providers/DiscordProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DiscordProviderConfigurator.php
@@ -21,7 +21,7 @@ class DiscordProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getProviderClass(array $config)
     {
-        return 'Discord\OAuth\Discord';
+        return 'Wohali\OAuth2\Client\Provider\Discord';
     }
 
     public function getProviderOptions(array $config)
@@ -34,12 +34,12 @@ class DiscordProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getPackagistName()
     {
-        return 'team-reflex/oauth2-discord';
+        return 'wohali/oauth2-discord-new';
     }
 
     public function getLibraryHomepage()
     {
-        return 'https://github.com/teamreflex/oauth2-discord';
+        return 'https://github.com/wohali/oauth2-discord-new';
     }
 
     public function getProviderDisplayName()


### PR DESCRIPTION
Because the previous library is only compatible with the ultra old `thephpleague/oauth2-client` in version` 1.x`.

The documentation no longer reference the library `https://github.com/teamreflex/oauth2-discord`. Instead, they promote https://github.com/wohali/oauth2-discord-new.

See: http://oauth2-client.thephpleague.com/providers/thirdparty/