### PR TITLE
Updating Facebook graph version to show 1.12 & not have a default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 1.19.0
+
+* For the `facebook` client, the `graph_api_version` is now *required*. It previously
+  defaulted to `v2.5`.
+
+## 1.18.0
+
+* [BC Break] If you're using the "discord" client, we've migrated to use a newer, not abandoned client - see #90

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ via Composer:
 | [Clever](https://github.com/schoolrunner/oauth2-clever)               | composer require schoolrunner/oauth2-clever         |
 | [DevianArt](https://github.com/SeinopSys/oauth2-deviantart)           | composer require seinopsys/oauth2-deviantart        |
 | [DigitalOcean](https://github.com/chrishemmings/oauth2-digitalocean)  | composer require chrishemmings/oauth2-digitalocean  |
-| [Discord](https://github.com/wohali/oauth2-discord-new)               | composer require wohali/oauth2-discord-new         |
+| [Discord](https://github.com/wohali/oauth2-discord-new)               | composer require wohali/oauth2-discord-new          |
 | [Dribbble](https://github.com/crewlabs/oauth2-dribbble)               | composer require crewlabs/oauth2-dribbble           |
 | [Dropbox](https://github.com/stevenmaguire/oauth2-dropbox)            | composer require stevenmaguire/oauth2-dropbox       |
 | [Drupal](https://github.com/chrishemmings/oauth2-drupal)              | composer require chrishemmings/oauth2-drupal        |
@@ -126,7 +126,7 @@ knpu_oauth2_client:
             redirect_route: connect_facebook_check
             # route parameters to pass to your route, if needed
             redirect_params: {}
-            graph_api_version: v2.3
+            graph_api_version: v2.12
 ```
 
 **See the full configuration for *all* the supported "types"
@@ -548,7 +548,7 @@ knpu_oauth2_client:
 
         # will create service: "knpu.oauth2.client.discord"
         # an instance of: KnpU\OAuth2ClientBundle\Client\Provider\DiscordClient
-        # composer require team-reflex/oauth2-discord
+        # composer require wohali/oauth2-discord-new
         discord:
             # must be "discord" - it activates that type!
             type: discord
@@ -670,7 +670,7 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: connect_facebook_check
             redirect_params: {}
-            graph_api_version: v2.5
+            graph_api_version: v2.12
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 

--- a/bin/update_readme
+++ b/bin/update_readme
@@ -108,11 +108,10 @@ foreach (KnpUOAuth2ClientExtension::getAllSupportedTypes() as $type) {
             $customKeys[] = '# '.$child->getInfo();
         }
 
-        // if not required, comment out, it's extra
-        $keyString = $child->isRequired() ? '' : '# ';
-        $customKeys[] = $keyString . sprintf(
-            '%s: %s', $child->getName(), $defaultValue
-        );
+        // if not required, comment out: it's extra
+        $keyPrefix = $child->isRequired() ? '' : '# ';
+        $example = $child->getExample() ? $child->getExample() : sprintf('%s: %s', $child->getName(), $defaultValue);
+        $customKeys[] = $keyPrefix . $example;
     }
 
     $newSection = str_replace('%PROVIDER_NAME%', $type, $sectionTemplate);

--- a/src/DependencyInjection/Providers/FacebookProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/FacebookProviderConfigurator.php
@@ -19,7 +19,7 @@ class FacebookProviderConfigurator implements ProviderConfiguratorInterface
         $node
             ->scalarNode('graph_api_version')
                 ->isRequired()
-                ->defaultValue('v2.5')
+                ->example('graph_api_version: v2.12')
             ->end()
         ;
     }


### PR DESCRIPTION
We defaulted the `graph_api_version` before to 2.5. That's not a good idea: the user *really* needs to specify this. Now it will be required (small BC break, but they will see it as a huge error immediately).

Also tweaked the README generator a bit. Other README changes are related to recent changes (and generated by `update_readme`).