### PR TITLE
Use the router to get the correct path from the connect facebook check route

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ class MyFacebookAuthenticator extends SocialAuthenticator
 
     public function supports(Request $request)
     {
-        // continue ONLY if the URL matches the check URL
-        return $request->getPathInfo() == $this->router->getRouteCollection()->get('connect_facebook_check')->getPath();
+        // continue ONLY if the current ROUTE matches the check ROUTE
+        return $request->attributes->get('_route') === 'connect_facebook_check';
     }
 
     public function getCredentials(Request $request)


### PR DESCRIPTION
Prevent problems like: https://github.com/knpuniversity/oauth2-client-bundle/issues/39