### PR TITLE
Add hint to call supports in getCredentials method for symfony lower than 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,7 @@ class MyFacebookAuthenticator extends SocialAuthenticator
     {
         // this method is only called if supports() returns true
 
-        // For Symfony < 4.0 the supports method need to be called manually
-        // uncomment the following code or remove it:
+        // For Symfony < 4.0 the supports method need to be called manually:
         // if (!$this->supports()) {
         //    return;
         // }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ class MyFacebookAuthenticator extends SocialAuthenticator
 
         // For Symfony lower than 3.4 the supports method need to be called manually here:
         // if (!$this->supports($request)) {
-        //    return null;
+        //     return null;
         // }
 
         return $this->fetchAccessToken($this->getFacebookClient());

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ class MyFacebookAuthenticator extends SocialAuthenticator
 
         // For Symfony lower than 3.4 the supports method need to be called manually here:
         // if (!$this->supports($request)) {
-        //    return;
+        //    return null;
         // }
 
         return $this->fetchAccessToken($this->getFacebookClient());

--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ class MyFacebookAuthenticator extends SocialAuthenticator
     {
         // this method is only called if supports() returns true
 
+        // For Symfony < 4.0 the supports method need to be called manually
+        // uncomment the following code or remove it:
+        // if (!$this->supports()) {
+        //    return;
+        // }
+
         return $this->fetchAccessToken($this->getFacebookClient());
     }
 

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ class MyFacebookAuthenticator extends SocialAuthenticator
     {
         // this method is only called if supports() returns true
 
-        // For Symfony < 4.0 the supports method need to be called manually:
-        // if (!$this->supports()) {
+        // For Symfony lower than 3.4 the supports method need to be called manually here:
+        // if (!$this->supports($request)) {
         //    return;
         // }
 


### PR DESCRIPTION
With https://github.com/knpuniversity/oauth2-client-bundle/pull/79 the docs is not longer working for lower than symfony 3.4. So a hint should be added how to get it work with <3.4