### PR TITLE
Missing config key for Auth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,9 +418,11 @@ knpu_oauth2_client:
         auth0:
             # must be "auth0" - it activates that type!
             type: auth0
-            # add and configure client_id and client_secret in parameters.yml
+            # add and configure client_id, client_secret and account in parameters.yml
             client_id: %auth0_client_id%
             client_secret: %auth0_client_secret%
+            # e.g. 'mycompany.auth0.com'
+            account: %auth0_account%
             # a route name you'll create
             redirect_route: connect_auth0_check
             redirect_params: {}

--- a/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
@@ -16,7 +16,12 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
 {
     public function buildConfiguration(NodeBuilder $node)
     {
-        // no custom options
+        $node
+            ->scalarNode('account')
+                ->isRequired()
+                ->info('Your Auth0 domain/account, e.g. \'mycompany.auth0.com\'')
+            ->end()
+        ;
     }
 
     public function getProviderClass(array $config)
@@ -29,6 +34,7 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
         return [
             'clientId' => $config['client_id'],
             'clientSecret' => $config['client_secret'],
+            'account' => $config['account']
         ];
     }
 

--- a/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
@@ -19,7 +19,7 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
         $node
             ->scalarNode('account')
                 ->isRequired()
-                ->info('Your Auth0 domain/account, e.g. \'mycompany.auth0.com\'')
+                ->info('Your Auth0 domain/account, e.g. "mycompany" if your domain is "mycompany.auth0.com"')
             ->end()
         ;
     }


### PR DESCRIPTION
Add mandatory config key 'account' for Auth0
Update README

Requested in #104 