### PR TITLE
Don't clear state after checking it

### DIFF
--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -90,7 +90,7 @@ class OAuth2Client
     public function getAccessToken()
     {
         if (!$this->isStateless) {
-            $expectedState = $this->getSession()->remove(self::OAUTH2_SESSION_STATE_KEY);
+            $expectedState = $this->getSession()->get(self::OAUTH2_SESSION_STATE_KEY);
             $actualState = $this->getCurrentRequest()->query->get('state');
             if (!$actualState || ($actualState !== $expectedState)) {
                 throw new InvalidStateException('Invalid state');

--- a/tests/Client/OAuth2ClientTest.php
+++ b/tests/Client/OAuth2ClientTest.php
@@ -120,7 +120,7 @@ class OAuth2ClientTest extends TestCase
         $this->request->query->set('state', 'THE_STATE');
         $this->request->query->set('code', 'CODE_ABC');
 
-        $this->session->remove(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
+        $this->session->get(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
             ->willReturn('THE_STATE');
 
         $expectedToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
@@ -158,7 +158,7 @@ class OAuth2ClientTest extends TestCase
     public function testGetAccessTokenThrowsInvalidStateException()
     {
         $this->request->query->set('state', 'ACTUAL_STATE');
-        $this->session->remove(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
+        $this->session->get(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
             ->willReturn('OTHER_STATE');
 
         $client = new OAuth2Client(
@@ -174,7 +174,7 @@ class OAuth2ClientTest extends TestCase
     public function testGetAccessTokenThrowsMissingAuthCodeException()
     {
         $this->request->query->set('state', 'ACTUAL_STATE');
-        $this->session->remove(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
+        $this->session->get(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
            ->willReturn('ACTUAL_STATE');
 
         // don't set a code query parameter


### PR DESCRIPTION
Fixes #123 and #111 

I originally removed the state from the session after checking it once to be extra careful. But, I can't think of a reason why keeping it in the session would cause a security issue.

Cheers!