### PR TITLE
Feature/#133 drupal provider base url not configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: connect_drupal_check
             redirect_params: {}
+            base_url: '%env(OAUTH_DRUPAL_BASE_URL)%'
 
             # whether to check OAuth2 "state": defaults to true
             # use_state: true

--- a/src/DependencyInjection/Providers/DrupalProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DrupalProviderConfigurator.php
@@ -16,7 +16,9 @@ class DrupalProviderConfigurator implements ProviderConfiguratorInterface
 {
     public function buildConfiguration(NodeBuilder $node)
     {
-        // no custom options
+        $node->scalarNode('base_url')
+          ->isRequired()
+          ->info('Drupal oAuth2 server URL');
     }
 
     public function getProviderClass(array $config)
@@ -29,6 +31,7 @@ class DrupalProviderConfigurator implements ProviderConfiguratorInterface
         return [
             'clientId' => $config['client_id'],
             'clientSecret' => $config['client_secret'],
+            'baseUrl' => $config['base_url'],
         ];
     }
 


### PR DESCRIPTION
Adds base_url as a configurable property and update the README configuration example to reflect the option.
