### PR TITLE
Added Oauth2ClientInterface for service decorating

### DIFF
--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -18,7 +18,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class OAuth2Client
+class OAuth2Client implements OAuth2ClientInterface
 {
     const OAUTH2_SESSION_STATE_KEY = 'knpu.oauth2_client_state';
 

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -14,15 +14,55 @@ use League\OAuth2\Client\Token\AccessToken;
 
 interface OAuth2ClientInterface
 {
+
+    /**
+     * Call this to avoid using and checking "state".
+     */
     public function setAsStateless();
 
+    /**
+     * Creates a RedirectResponse that will send the user to the
+     * OAuth2 server (e.g. send them to Facebook).
+     *
+     * @param array $scopes  The scopes you want (leave empty to use default)
+     * @param array $options Extra options to pass to the "Provider" class
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
     public function redirect(array $scopes, array $options);
 
+    /**
+     * Call this after the user is redirected back to get the access token.
+     *
+     * @return \League\OAuth2\Client\Token\AccessToken
+     *
+     * @throws \KnpU\OAuth2ClientBundle\Exception\InvalidStateException
+     * @throws \KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException
+     * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException If token cannot be fetched
+     */
     public function getAccessToken();
 
+    /**
+     * Returns the "User" information (called a resource owner).
+     *
+     * @param AccessToken $accessToken
+     * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
+     */
     public function fetchUserFromToken(AccessToken $accessToken);
 
+    /**
+     * Shortcut to fetch the access token and user all at once.
+     *
+     * Only use this if you don't need the access token, but only
+     * need the user.
+     *
+     * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
+     */
     public function fetchUser();
 
+    /**
+     * Returns the underlying OAuth2 provider.
+     *
+     * @return \League\OAuth2\Client\Provider\AbstractProvider
+     */
     public function getOAuth2Provider();
 }

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KnpU\OAuth2ClientBundle\Client;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+interface OAuth2ClientInterface
+{
+    public function setAsStateless();
+
+    public function redirect(array $scopes, array $options);
+
+    public function getAccessToken();
+
+    public function fetchUserFromToken(AccessToken $accessToken);
+
+    public function fetchUser();
+
+    public function getOAuth2Provider();
+}


### PR DESCRIPTION
Example:
```php

namespace App\Client;

class CacheableClient implements OAuth2ClientInterface
{
    private $client;
    private $cache;

    public function __construct(OAuth2ClientInterface $client, Cache $cache)
    {
        // ...
    }

    // override all public functions, call the method on the internal $this->client object
    // but add caching wherever you need it
}
```

```yaml
services:
    app.azure_client:
        class: App\Client\CacheableClient
        decorates: knpu.oauth2.client.azure
```
closes #134 