### PR TITLE
added ability to configure default http_client

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,12 +17,20 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('knpu_oauth2_client');
+        $treeBuilder = new TreeBuilder('knpu_oauth2_client');
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('knpu_oauth2_client');
 
         $rootNode
             ->children()
             ->scalarNode('http_client')->defaultNull()->info('Service id of HTTP client to use (must implement GuzzleHttp\ClientInterface)')->end()
+            ->arrayNode('http_client_options')
+                ->info('')
+                ->children()
+                    ->integerNode('timeout')->min(0)->end()
+                    ->scalarNode('proxy')->end()
+                    ->booleanNode('verify')->info('Use only with proxy option set')->end()
+                ->end()
+            ->end()
             ->arrayNode('clients')
                 ->normalizeKeys(false)
                 ->useAttributeAsKey('variable')

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -155,6 +155,7 @@ class KnpUOAuth2ClientExtension extends Extension
         $loader->load('services.xml');
 
         $httpClient = $config['http_client'];
+        $httpClientOptions = array_key_exists('http_client_options', $config) ? $config['http_client_options'] : [];
         $clientConfigurations = $config['clients'];
 
         $clientServiceKeys = [];
@@ -162,7 +163,7 @@ class KnpUOAuth2ClientExtension extends Extension
             // manually make sure "type" is there
             if (!isset($clientConfig['type'])) {
                 throw new InvalidConfigurationException(sprintf(
-                    'Your "knpu_oauth2_client.clients." config entry is missing the "type" key.',
+                    'Your "knpu_oauth2_client.clients.%s" config entry is missing the "type" key.',
                     $key
                 ));
             }
@@ -186,9 +187,13 @@ class KnpUOAuth2ClientExtension extends Extension
 
             $configurator = $this->getConfigurator($type);
 
+            $providerOptions = $configurator->getProviderOptions($config);
+
             $collaborators = [];
             if ($httpClient) {
                 $collaborators['httpClient'] = new Reference($httpClient);
+            } else {
+                $providerOptions = array_merge($providerOptions, $httpClientOptions);
             }
             // hey, we should add the provider/client service!
             $clientServiceKey = $this->configureProviderAndClient(
@@ -198,7 +203,7 @@ class KnpUOAuth2ClientExtension extends Extension
                 $configurator->getProviderClass($config),
                 $configurator->getClientClass($config),
                 $configurator->getPackagistName(),
-                $configurator->getProviderOptions($config),
+                $providerOptions,
                 $config['redirect_route'],
                 $config['redirect_params'],
                 $config['use_state'],

--- a/tests/app/TestKernel.php
+++ b/tests/app/TestKernel.php
@@ -61,4 +61,14 @@ class TestKernel extends Kernel
             ]);
         });
     }
+
+    public function getCacheDir()
+    {
+        return $this->getProjectDir().'/tests/app/cache/'.$this->getEnvironment();
+    }
+
+    public function getLogDir()
+    {
+        return $this->getProjectDir().'/tests/app/log';
+    }
 }


### PR DESCRIPTION
Added to config new options
```yaml
http_client_options:
    timeout: '30' # seconds 
    proxy: 'proxy_url' # proxy url string
    verify: true|false # verify or not ssl certificate
```

Fixed some bugs
* symfony 4.2 deprecation
* wrong cache & log dirs in tests
* missed `%s` in `InvalidConfigurationException` message