### PR TITLE
Update DependencyInjection to account for changes in Symfony 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * OAuth2 Client Bundle
  * Copyright (c) KnpUniversity <http://knpuniversity.com/>
  *

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * OAuth2 Client Bundle
  * Copyright (c) KnpUniversity <http://knpuniversity.com/>
  *

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,11 +17,11 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('knpu_oauth2_client');
-        if (method_exists($treeBuilder, 'getRootNode'))
+        if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
-        else
+        } else {
             $rootNode = $treeBuilder->root('knpu_oauth2_client');
-
+        }
         $rootNode
             ->children()
             ->scalarNode('http_client')->defaultNull()->info('Service id of HTTP client to use (must implement GuzzleHttp\ClientInterface)')->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * OAuth2 Client Bundle
  * Copyright (c) KnpUniversity <http://knpuniversity.com/>
@@ -17,8 +16,11 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('knpu_oauth2_client');
+        $treeBuilder = new TreeBuilder('knpu_oauth2_client');
+        if (method_exists($treeBuilder, 'getRootNode'))
+            $rootNode = $treeBuilder->getRootNode();
+        else
+            $rootNode = $treeBuilder->root('knpu_oauth2_client');
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * OAuth2 Client Bundle
  * Copyright (c) KnpUniversity <http://knpuniversity.com/>
  *

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -1,5 +1,6 @@
 <?php
-/**
+
+/*
  * OAuth2 Client Bundle
  * Copyright (c) KnpUniversity <http://knpuniversity.com/>
  *

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -180,8 +180,11 @@ class KnpUOAuth2ClientExtension extends Extension
             }
 
             // process the configuration
-            $tree = new TreeBuilder();
-            $node = $tree->root('knpu_oauth2_client/clients/' . $key);
+            $tree = new TreeBuilder('knpu_oauth2_client/clients/' . $key);
+            if (method_exists($tree, 'getRootNode'))
+                $node = $tree->getRootNode();
+            else
+                $node = $tree->root('knpu_oauth2_client/clients/' . $key);
             $this->buildConfigurationForType($node, $type);
             $processor = new Processor();
             $config = $processor->process($tree->buildTree(), [$clientConfig]);

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -181,10 +181,11 @@ class KnpUOAuth2ClientExtension extends Extension
 
             // process the configuration
             $tree = new TreeBuilder('knpu_oauth2_client/clients/' . $key);
-            if (method_exists($tree, 'getRootNode'))
+            if (method_exists($tree, 'getRootNode')) {
                 $node = $tree->getRootNode();
-            else
+            } else {
                 $node = $tree->root('knpu_oauth2_client/clients/' . $key);
+            }
             $this->buildConfigurationForType($node, $type);
             $processor = new Processor();
             $config = $processor->process($tree->buildTree(), [$clientConfig]);


### PR DESCRIPTION
Symfony 4.2 asks for the tree builder root to be defined in the construct of the TreeBuilder.  This change ensures backwards compatibilty and allows correct operation with future Symfony framework versions.