### PR TITLE
Adding "api_version" and "fields" options for Linkedin's provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,8 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: connect_linkedin_check
             redirect_params: {}
+            # Optional value to specify Linkedin's API version to use. As the time of writing, v1 is still used by default by league/oauth2-linkedin.
+            # api_version: null
             # Optional value to specify fields to be requested from the profile. Since Linkedin\'s API upgrade from v1 to v2, fields and authorizations policy have been enforced. See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin for more details.
             # fields: []
             # whether to check OAuth2 "state": defaults to true

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ class FacebookController extends Controller
     public function connectAction(ClientRegistry $clientRegistry)
     {
         // on Symfony 3.3 or lower, $clientRegistry = $this->get('knpu.oauth2.registry');
-    
+
         // will redirect to Facebook!
         return $clientRegistry
             ->getClient('facebook_main') // key used in config/packages/knpu_oauth2_client.yaml
@@ -950,7 +950,8 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: connect_linkedin_check
             redirect_params: {}
-
+            # Optional value to specify fields to be requested from the profile. Since Linkedin\'s API upgrade from v1 to v2, fields and authorizations policy have been enforced. See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin for more details.
+            # fields: []
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 
@@ -1286,7 +1287,7 @@ you can use.
 
 ## Extending/Decorating Client Classes
 
-Maybe you need some extra services inside your client class? No problem! You can 
+Maybe you need some extra services inside your client class? No problem! You can
 decorate existing client class with your own implementation. All you need is
 new class that implement OAuth2ClientInterface:
 

--- a/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
@@ -16,7 +16,12 @@ class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
 {
     public function buildConfiguration(NodeBuilder $node)
     {
-        // no custom options
+        $node
+            ->arrayNode('fields')
+                ->prototype('scalar')->end()
+                ->info('Optional value to specify fields to be requested from the profile. Since Linkedin\'s API upgrade from v1 to v2, fields and authorizations policy have been enforced. See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin for more details.')
+            ->end()
+        ;
     }
 
     public function getProviderClass(array $config)
@@ -26,10 +31,16 @@ class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getProviderOptions(array $config)
     {
-        return [
+        $options = [
             'clientId' => $config['client_id'],
             'clientSecret' => $config['client_secret'],
         ];
+
+        if (!empty($config['fields'])) {
+            $options['fields'] = $config['fields'];
+        }
+
+        return $options;
     }
 
     public function getPackagistName()

--- a/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
@@ -17,6 +17,10 @@ class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
     public function buildConfiguration(NodeBuilder $node)
     {
         $node
+            ->integerNode('api_version')
+                ->defaultNull()
+                ->info('Optional value to specify Linkedin\'s API version to use. As the time of writing, v1 is still used by default by league/oauth2-linkedin.')
+            ->end()
             ->arrayNode('fields')
                 ->prototype('scalar')->end()
                 ->info('Optional value to specify fields to be requested from the profile. Since Linkedin\'s API upgrade from v1 to v2, fields and authorizations policy have been enforced. See https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin for more details.')
@@ -35,6 +39,10 @@ class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
             'clientId' => $config['client_id'],
             'clientSecret' => $config['client_secret'],
         ];
+
+        if (!is_null($config['api_version'])) {
+            $options['resourceOwnerVersion'] = $config['api_version'];
+        }
 
         if (!empty($config['fields'])) {
             $options['fields'] = $config['fields'];


### PR DESCRIPTION
Hi,

I ran into some issues implementing Linkedin OAuth, basically because:

1. Linkedin is switching from v1 to v2 of their APIs, and there is no way to specify version to use from this bundle. Since all new Linkedin API project cannot use v1, OAuth is unusable with this bundle. PHPLeague oauth2-linkedin provider provide a withResourceOwnerVersion() method since 4.1.0 to set version to use, and I'm planning to submit a PR with this feature in this repo, but said that, I must take one thing at a time :)

2. In conjunction of their version upgrade, Linkedin enforced their policy, and some of the default fields retrieved from PHPLeague provider are now forbidden without requesting developer authorization, so after authentication, it's all 403 responses (=> "Not enough permissions to access: GET /me"). Furthermore, fields that are still available from v1 to v2 changed names ("first-name" becomes "firstName" for example). Fortunately, PHPLeague Linkedin provider allows to overload retrieved fields, so here is my PR!

If you have any suggestions, do not hesitate since I'm new to open-source contributions ;)