### PR TITLE
Fail CI if repo is in dirty state after bin/update_readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ before_install:
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 # Fail CI if repo is in dirty state after bin/update_readme
-before_script: ./bin/update_readme && git diff --exit-code
+before_script: ./bin/update_readme && git diff --exit-code README.md
 
 script: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_install:
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 # Fail CI if repo is in dirty state after bin/update_readme
-before_script: ./bin/update_readme && git diff --exit-code README.md
+before_script:
+    - ./bin/update_readme
+    - git diff --exit-code README.md
 
 script: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,7 @@ before_install:
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
+# Fail CI if repo is in dirty state after bin/update_readme
+before_script: ./bin/update_readme && git diff --exit-code
+
 script: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 # Fail CI if repo is in dirty state after bin/update_readme
-before_script:
-    - ./bin/update_readme
-    - git diff --exit-code README.md
+before_script: ./bin/update_readme && git diff --exit-code README.md
 
 script: ./vendor/bin/phpunit


### PR DESCRIPTION
This will help us to catch inconsistence in README on CI level. No more missing call of `bin/update_readme`!

The build should be green after #171 is merged