### PR TITLE
Bumping minimum php version to 7.1 and removing support for EOL Symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,14 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
 matrix:
     include:
-        - php: 7.1
-          env: DEPENDENCIES=dev
-        - php: 7.2
-          env: DEPENDENCIES=dev
         - php: 7.3
           env: DEPENDENCIES=dev
-        - php: 5.5
+        - php: 7.1
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
 
 before_install:

--- a/bin/update_readme
+++ b/bin/update_readme
@@ -62,8 +62,10 @@ foreach (KnpUOAuth2ClientExtension::getAllSupportedTypes() as $type) {
         continue;
     }
 
-    $tree = new TreeBuilder();
-    $configNode = $tree->root('generating_readme');
+    $tree = new TreeBuilder('knpu_oauth2_client');
+    $configNode = method_exists($tree, 'getRootNode')
+        ? $tree->getRootNode()
+        : $tree->root('knpu_oauth2_client');
     $configurator = $extension->getConfigurator($type);
     $configurator->buildConfiguration($configNode->children());
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": " >=5.5.9",
-        "symfony/framework-bundle": "^2.7|^3.0|^4.0",
-        "symfony/dependency-injection": "^2.8|^3.0|^4.0",
-        "symfony/routing": "^2.7|^3.0|^4.0",
-        "symfony/http-foundation": "^2.7|^3.0|^4.0",
+        "php": "^7.1.3",
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
+        "symfony/routing": "^3.4|^4.0",
+        "symfony/http-foundation": "^3.4|^4.0",
         "league/oauth2-client": "^1.0|^2.0"
     },
     "autoload": {
@@ -27,8 +27,9 @@
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1|^2.0",
-        "symfony/security-guard": "^2.8|^3.0",
-        "phpunit/phpunit": "^4.8.36"
+        "phpunit/phpunit": "^7.5",
+        "symfony/security-guard": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -42,6 +42,9 @@ class ConfigurationTest extends TestCase
             if (!$expectsException) {
                 throw $e;
             }
+
+            // placeholder assertion when we expect an exception
+            $this->assertTrue(true);
         }
     }
 

--- a/tests/Security/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/Security/Authenticator/SocialAuthenticatorTest.php
@@ -70,6 +70,9 @@ class StubSocialAuthenticator extends SocialAuthenticator
     public function start(Request $request, AuthenticationException $authException = null)
     {
     }
+    public function supports(Request $request)
+    {
+    }
     public function getCredentials(Request $request)
     {
     }

--- a/tests/Security/User/OAuthUserProviderTest.php
+++ b/tests/Security/User/OAuthUserProviderTest.php
@@ -12,7 +12,6 @@ namespace KnpU\OAuth2ClientBundle\Tests\Security\User;
 
 use KnpU\OAuth2ClientBundle\Security\User\OAuthUser;
 use KnpU\OAuth2ClientBundle\Security\User\OAuthUserProvider;
-use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 use PHPUnit\Framework\TestCase;
@@ -38,13 +37,14 @@ class OAuthUserProviderTest extends TestCase
         $this->assertEquals($expected, $userProvider->refreshUser($user));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
+     */
     public function testRefreshOtherUser()
     {
         $userProvider = new OAuthUserProvider();
 
-        $this->setExpectedException(UnsupportedUserException::class);
-
-        $userProvider->refreshUser($this->getMock(UserInterface::class));
+        $userProvider->refreshUser($this->createMock(UserInterface::class));
     }
 
     /**


### PR DESCRIPTION
Hi!

This removes support for PHP 5.6, 5.7 and 7.0, which are EOL and also removes support for all Symfony versions before 3.4. This will be included in the next minor version, so it simply means that you need to be on an actively maintained version of Symfony and PHP in order to update from here.

Cheers!