### PR TITLE
add phpstan check to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 matrix:
     include:
         - php: 7.3
-          env: DEPENDENCIES=dev
+          env: DEPENDENCIES=dev LINT=1
         - php: 7.1
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
 
@@ -27,4 +27,6 @@ install: composer update --prefer-dist $COMPOSER_FLAGS
 # Fail CI if repo is in dirty state after bin/update_readme
 before_script: ./bin/update_readme && git diff --exit-code README.md
 
-script: ./vendor/bin/simple-phpunit
+script:
+    - ./vendor/bin/simple-phpunit
+    - if [ "$LINT" = 1 ]; then ./vendor/bin/phpstan analyse; fi;

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "league/oauth2-facebook": "^1.1|^2.0",
         "symfony/security-guard": "^3.4|^4.0",
         "symfony/yaml": "^3.4|^4.0",
-        "phpspec/prophecy": "^1.8"
+        "phpspec/prophecy": "^1.8",
+        "phpstan/phpstan": "^0.11.16"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,7 @@
 parameters:
-	autoload_files:
-		- ./vendor/bin/.phpunit/phpunit-7.4/vendor/autoload.php
 	level: 7
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- ./src/
-		- ./tests/
 	excludes_analyse:
 		- */cache/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,3 +13,7 @@ parameters:
 		-
 			message: '#Return typehint of method KnpU\\OAuth2ClientBundle\\Client\\Provider\\[a-zA-Z0-9\\_]+::fetchUser\(\) has invalid type [a-zA-Z0-9\\_]#'
 			path: ./src/Client/Provider
+		# False positive: using `::class` is not an error for those providers `::getProviderClass()` method.
+		-
+			message: '#Class [a-zA-Z0-9\\_]+ not found#'
+			path: ./src/DependencyInjection/Providers

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+	autoload_files:
+		- ./vendor/bin/.phpunit/phpunit-7.4/vendor/autoload.php
+	level: 7
+	inferPrivatePropertyTypeFromConstructor: true
+	paths:
+		- ./src/
+		- ./tests/
+	excludes_analyse:
+		- */cache/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,11 @@ parameters:
 		- ./src/
 	excludes_analyse:
 		- */cache/*
+	ignoreErrors:
+		# False positive: clients are not dependencies of this project.
+		-
+			message: '#Return typehint of method KnpU\\OAuth2ClientBundle\\Client\\Provider\\[a-zA-Z0-9\\_]+::fetchUserFromToken\(\) has invalid type [a-zA-Z0-9\\_]#'
+			path: ./src/Client/Provider
+		-
+			message: '#Return typehint of method KnpU\\OAuth2ClientBundle\\Client\\Provider\\[a-zA-Z0-9\\_]+::fetchUser\(\) has invalid type [a-zA-Z0-9\\_]#'
+			path: ./src/Client/Provider

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-	level: 7
+	level: 1
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- ./src/


### PR DESCRIPTION
See issue #88 

Here's a first try to integrate phpstan :)

With the higher phpstan level (the higher the stricter), i.e. 7, there is at this moment 221 errors detected.

Not all of them are relevant IMHO.
For instance there is a lot of "errors" like ` Return typehint of method KnpU\OAuth2ClientBundle\Client\Provider\SlackClient::fetchUserFromToken() has invalid type AdamPaterson\OAuth2\Client\Provider\SlackResourceOwner.` that could be ignore.

I'd like to have opinion of others about how to proceed about the detected errors.
Do we handle them in this PR?
Which errors should be ignored?
Should we decrease the phpstan level at first and increase it little by little?