### PR TITLE
Allow overriding parts of a client config

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('variable')
                     ->prototype('array')
+                        ->useAttributeAsKey('variable')
                         ->prototype('variable')->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
Assuming two different config files:

```yaml
knpu_oauth2_client:
    clients:
        drupal:
            client_id: foo
            client_secret: foo
            type: drupal
            redirect_route: foo
            base_url: foo
```

```yaml
imports:
    - { resource: config.yml }

knpu_oauth2_client:
    clients:
         drupal:
             client_id: bar
```

This will cause an `InvalidConfigurationException`:
```
Unrecognized option "0" under "knpu_oauth2_client/clients/drupal"
```

This PR fixes this error and allows overriding parts of the configuration.

(See https://github.com/symfony/symfony/issues/12304#issuecomment-63910362 for a more detailed explanation.)