### PR TITLE
added the custom_domain parameter to the auth0 client library config

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,8 +470,12 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: connect_auth0_check
             redirect_params: {}
+            # Your custom/definite Auth0 domain, e.g. "login.mycompany.com". Set this if you use Auth0's Custom Domain feature. The "account" and "region" parameters will be ignored in this case.
+            custom_domain: null
             # Your Auth0 domain/account, e.g. "mycompany" if your domain is "mycompany.auth0.com"
             account: null
+            # Your Auth0 region, e.g. "eu" if your tenant is in the EU.
+            # region: null
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 

--- a/README.md
+++ b/README.md
@@ -471,9 +471,9 @@ knpu_oauth2_client:
             redirect_route: connect_auth0_check
             redirect_params: {}
             # Your custom/definite Auth0 domain, e.g. "login.mycompany.com". Set this if you use Auth0's Custom Domain feature. The "account" and "region" parameters will be ignored in this case.
-            custom_domain: null
+            # custom_domain: null
             # Your Auth0 domain/account, e.g. "mycompany" if your domain is "mycompany.auth0.com"
-            account: null
+            # account: null
             # Your Auth0 region, e.g. "eu" if your tenant is in the EU.
             # region: null
             # whether to check OAuth2 "state": defaults to true

--- a/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
@@ -17,9 +17,14 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
     public function buildConfiguration(NodeBuilder $node)
     {
         $node
+            ->scalarNode('custom_domain')
+                ->info('Your custom/definite Auth0 domain, e.g. "login.mycompany.com". Set this if you use Auth0\'s Custom Domain feature. The "account" and "region" parameters will be ignored in this case.')
+            ->end()
             ->scalarNode('account')
-                ->isRequired()
                 ->info('Your Auth0 domain/account, e.g. "mycompany" if your domain is "mycompany.auth0.com"')
+            ->end()
+            ->scalarNode('region')
+                ->info('Your Auth0 region, e.g. "eu" if your tenant is in the EU.')
             ->end()
         ;
     }
@@ -34,7 +39,9 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
         return [
             'clientId' => $config['client_id'],
             'clientSecret' => $config['client_secret'],
+            'customDomain' => $config['custom_domain'],
             'account' => $config['account'],
+            'region' => $config['region'],
         ];
     }
 

--- a/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
@@ -18,12 +18,15 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
     {
         $node
             ->scalarNode('custom_domain')
+                ->defaultNull()
                 ->info('Your custom/definite Auth0 domain, e.g. "login.mycompany.com". Set this if you use Auth0\'s Custom Domain feature. The "account" and "region" parameters will be ignored in this case.')
             ->end()
             ->scalarNode('account')
+                ->defaultNull()
                 ->info('Your Auth0 domain/account, e.g. "mycompany" if your domain is "mycompany.auth0.com"')
             ->end()
             ->scalarNode('region')
+                ->defaultNull()
                 ->info('Your Auth0 region, e.g. "eu" if your tenant is in the EU.')
             ->end()
         ;


### PR DESCRIPTION
This PR makes possible to use the the auth0 client library with a custom domain setting.
It depends on this PR in the client library: https://github.com/RiskioFr/oauth2-auth0/pull/16

The `account` parameter is not required anymore, as the `custom_domain` parameter takes priority if it's set. It is implemented in a backward compatible way.