### PR TITLE
Allow any OAuth2ClientInterface implementation in ClientRegistry

### DIFF
--- a/src/Client/ClientRegistry.php
+++ b/src/Client/ClientRegistry.php
@@ -37,15 +37,15 @@ class ClientRegistry
      *
      * @param string $key
      *
-     * @return OAuth2Client
+     * @return OAuth2ClientInterface
      */
     public function getClient($key)
     {
         if (isset($this->serviceMap[$key])) {
             $client = $this->container->get($this->serviceMap[$key]);
-            if (!$client instanceof OAuth2Client) {
+            if (!$client instanceof OAuth2ClientInterface) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Somehow the "%s" client is not an instance of OAuth2Client.',
+                    'Somehow the "%s" client is not an instance of OAuth2ClientInterface.',
                     $key
                 ));
             }


### PR DESCRIPTION
The client registry should allow any OAuth2ClientInterface implementation.

Fixes and error introduced in https://github.com/knpuniversity/oauth2-client-bundle/commit/61af3d7c7510e5f51537d3895e239aec87860c98 similar to #159.

