### PR TITLE
making client_secret optional to support apple provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,13 +467,13 @@ knpu_oauth2_client:
             type: apple
             # add and configure client_id and client_secret in parameters.yml
             client_id: '%env(OAUTH_APPLE_CLIENT_ID)%'
-            client_secret: '%env(OAUTH_APPLE_CLIENT_SECRET)%'
+
             # a route name you'll create
             redirect_route: connect_apple_check
             redirect_params: {}
-            # team_id: null
-            # key_file_id: null
-            # key_file_path: null
+            team_id: null
+            key_file_id: null
+            key_file_path: null
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 

--- a/bin/update_readme
+++ b/bin/update_readme
@@ -40,7 +40,7 @@ $sectionTemplate = <<<EOF
             type: %PROVIDER_NAME%
             # add and configure client_id and client_secret in parameters.yml
             client_id: '%env(OAUTH_%UCPROVIDER_NAME%_CLIENT_ID)%'
-            client_secret: '%env(OAUTH_%UCPROVIDER_NAME%_CLIENT_SECRET)%'
+            %CLIENT_SECRET%
             # a route name you'll create
             redirect_route: connect_%PROVIDER_NAME%_check
             redirect_params: {}
@@ -122,7 +122,23 @@ foreach (KnpUOAuth2ClientExtension::getAllSupportedTypes() as $type) {
         $customKeys[] = $keyPrefix . $example;
     }
 
-    $newSection = str_replace('%UCPROVIDER_NAME%', strtoupper($type), $sectionTemplate);
+    $newSection = $sectionTemplate;
+
+    if (KnpUOAuth2ClientExtension::configuratorNeedsClientSecret($configurator)) {
+        $newSection = str_replace(
+            '%CLIENT_SECRET%',
+            "client_secret: '%env(OAUTH_%UCPROVIDER_NAME%_CLIENT_SECRET)%'",
+            $newSection
+        );
+    } else {
+        $newSection = str_replace(
+            '            %CLIENT_SECRET%',
+            '',
+            $newSection
+        );
+    }
+
+    $newSection = str_replace('%UCPROVIDER_NAME%', strtoupper($type), $newSection);
     $newSection = str_replace('%PROVIDER_NAME%', $type, $newSection);
     $newSection = str_replace('%CLIENT_CLASS%', $configurator->getClientClass(array()), $newSection);
     $newSection = str_replace('%PACKAGE_NAME%', $configurator->getPackagistName(), $newSection);

--- a/src/Client/ClientRegistry.php
+++ b/src/Client/ClientRegistry.php
@@ -22,9 +22,6 @@ class ClientRegistry
 
     /**
      * ClientRegistry constructor.
-     *
-     * @param ContainerInterface $container
-     * @param array              $serviceMap
      */
     public function __construct(ContainerInterface $container, array $serviceMap)
     {
@@ -44,20 +41,13 @@ class ClientRegistry
         if (isset($this->serviceMap[$key])) {
             $client = $this->container->get($this->serviceMap[$key]);
             if (!$client instanceof OAuth2ClientInterface) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Somehow the "%s" client is not an instance of OAuth2ClientInterface.',
-                    $key
-                ));
+                throw new \InvalidArgumentException(sprintf('Somehow the "%s" client is not an instance of OAuth2ClientInterface.', $key));
             }
 
             return $client;
         }
 
-        throw new \InvalidArgumentException(sprintf(
-            'There is no OAuth2 client called "%s". Available are: %s',
-            $key,
-            implode(', ', array_keys($this->serviceMap))
-        ));
+        throw new \InvalidArgumentException(sprintf('There is no OAuth2 client called "%s". Available are: %s', $key, implode(', ', array_keys($this->serviceMap))));
     }
 
     /**

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -34,9 +34,6 @@ class OAuth2Client implements OAuth2ClientInterface
 
     /**
      * OAuth2Client constructor.
-     *
-     * @param AbstractProvider $provider
-     * @param RequestStack     $requestStack
      */
     public function __construct(AbstractProvider $provider, RequestStack $requestStack)
     {
@@ -112,8 +109,6 @@ class OAuth2Client implements OAuth2ClientInterface
 
     /**
      * Returns the "User" information (called a resource owner).
-     *
-     * @param AccessToken $accessToken
      *
      * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
      */

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -44,8 +44,6 @@ interface OAuth2ClientInterface
     /**
      * Returns the "User" information (called a resource owner).
      *
-     * @param AccessToken $accessToken
-     *
      * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken);

--- a/src/Client/Provider/AmazonClient.php
+++ b/src/Client/Provider/AmazonClient.php
@@ -17,8 +17,6 @@ use Luchianenco\OAuth2\Client\Provider\AmazonResourceOwner;
 class AmazonClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return AmazonResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/AppleClient.php
+++ b/src/Client/Provider/AppleClient.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;

--- a/src/Client/Provider/Auth0Client.php
+++ b/src/Client/Provider/Auth0Client.php
@@ -17,8 +17,6 @@ use Riskio\OAuth2\Client\Provider\Auth0ResourceOwner;
 class Auth0Client extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return Auth0ResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/AzureClient.php
+++ b/src/Client/Provider/AzureClient.php
@@ -17,8 +17,6 @@ use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
 class AzureClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return AzureResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/BitbucketClient.php
+++ b/src/Client/Provider/BitbucketClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\BitbucketResourceOwner;
 class BitbucketClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return BitbucketResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/BoxClient.php
+++ b/src/Client/Provider/BoxClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\BoxResourceOwner;
 class BoxClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return BoxResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/BufferClient.php
+++ b/src/Client/Provider/BufferClient.php
@@ -17,8 +17,6 @@ use Tgallice\OAuth2\Client\Provider\BufferUser;
 class BufferClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return BufferUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/CanvasLMSClient.php
+++ b/src/Client/Provider/CanvasLMSClient.php
@@ -17,8 +17,6 @@ use smtech\OAuth2\Client\Provider\CanvasLMSResourceOwner;
 class CanvasLMSClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return CanvasLMSResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/CleverClient.php
+++ b/src/Client/Provider/CleverClient.php
@@ -17,8 +17,6 @@ use Schoolrunner\OAuth2\Client\User\CleverUser;
 class CleverClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return CleverUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DevianArtClient.php
+++ b/src/Client/Provider/DevianArtClient.php
@@ -17,8 +17,6 @@ use SeinopSys\OAuth2\Client\Provider\DeviantArtResourceOwner;
 class DevianArtClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DeviantArtResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DigitalOceanClient.php
+++ b/src/Client/Provider/DigitalOceanClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use ChrisHemmings\OAuth2\Client\Provider\DigitalOceanResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use ChrisHemmings\OAuth2\Client\Provider\DigitalOceanResourceOwner;
 
 class DigitalOceanClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DigitalOceanResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DiscordClient.php
+++ b/src/Client/Provider/DiscordClient.php
@@ -17,8 +17,6 @@ use Wohali\OAuth2\Client\Provider\DiscordResourceOwner;
 class DiscordClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DiscordResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DribbbleClient.php
+++ b/src/Client/Provider/DribbbleClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use CrewLabs\OAuth2\Client\Provider\DribbbleResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use CrewLabs\OAuth2\Client\Provider\DribbbleResourceOwner;
 
 class DribbbleClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DribbbleResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DropboxClient.php
+++ b/src/Client/Provider/DropboxClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\DropboxResourceOwner;
 class DropboxClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DropboxResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/DrupalClient.php
+++ b/src/Client/Provider/DrupalClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use ChrisHemmings\OAuth2\Client\Provider\DrupalResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use ChrisHemmings\OAuth2\Client\Provider\DrupalResourceOwner;
 
 class DrupalClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return DrupalResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/ElanceClient.php
+++ b/src/Client/Provider/ElanceClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\ElanceResourceOwner;
 class ElanceClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return ElanceResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/EveOnlineClient.php
+++ b/src/Client/Provider/EveOnlineClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
-use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use Evelabs\OAuth2\Client\Provider\EveOnlineResourceOwner;
+use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
 
 class EveOnlineClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return EveOnlineResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/EventbriteClient.php
+++ b/src/Client/Provider/EventbriteClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\EventbriteResourceOwner;
 class EventbriteClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return EventbriteResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/FacebookClient.php
+++ b/src/Client/Provider/FacebookClient.php
@@ -17,8 +17,6 @@ use League\OAuth2\Client\Token\AccessToken;
 class FacebookClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return FacebookUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/FitbitClient.php
+++ b/src/Client/Provider/FitbitClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use djchen\OAuth2\Client\Provider\FitbitUser;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use djchen\OAuth2\Client\Provider\FitbitUser;
 
 class FitbitClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return FitbitUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/FoursquareClient.php
+++ b/src/Client/Provider/FoursquareClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\FoursquareResourceOwner;
 class FoursquareClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return FoursquareResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/GeocachingClient.php
+++ b/src/Client/Provider/GeocachingClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\GeocachingResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
 
 class GeocachingClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return GeocachingResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/GithubClient.php
+++ b/src/Client/Provider/GithubClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\GithubResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
 
 class GithubClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return GithubResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/GitlabClient.php
+++ b/src/Client/Provider/GitlabClient.php
@@ -22,8 +22,6 @@ use Omines\OAuth2\Client\Provider\GitlabResourceOwner;
 class GitlabClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return GitlabResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/GoogleClient.php
+++ b/src/Client/Provider/GoogleClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\GoogleUser;
+use League\OAuth2\Client\Token\AccessToken;
 
 class GoogleClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return GoogleUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/HeadHunterClient.php
+++ b/src/Client/Provider/HeadHunterClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use AlexMasterov\OAuth2\Client\Provider\HeadHunterResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use AlexMasterov\OAuth2\Client\Provider\HeadHunterResourceOwner;
 
 class HeadHunterClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return HeadHunterResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/HerokuClient.php
+++ b/src/Client/Provider/HerokuClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\HerokuResourceOwner;
 class HerokuClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return HerokuResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/InstagramClient.php
+++ b/src/Client/Provider/InstagramClient.php
@@ -17,8 +17,6 @@ use League\OAuth2\Client\Token\AccessToken;
 class InstagramClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return InstagramResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/JiraClient.php
+++ b/src/Client/Provider/JiraClient.php
@@ -17,8 +17,6 @@ use Mrjoops\OAuth2\Client\Provider\JiraResourceOwner;
 class JiraClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return JiraResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/KeycloakClient.php
+++ b/src/Client/Provider/KeycloakClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\KeycloakResourceOwner;
 class KeycloakClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return KeycloakResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/LinkedInClient.php
+++ b/src/Client/Provider/LinkedInClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\LinkedInResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
 
 class LinkedInClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return LinkedInResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/MailRuClient.php
+++ b/src/Client/Provider/MailRuClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use Aego\OAuth2\Client\Provider\MailruResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use Aego\OAuth2\Client\Provider\MailruResourceOwner;
 
 class MailRuClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return MailruResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/MicrosoftClient.php
+++ b/src/Client/Provider/MicrosoftClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\MicrosoftResourceOwner;
 class MicrosoftClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return MicrosoftResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/MollieClient.php
+++ b/src/Client/Provider/MollieClient.php
@@ -17,8 +17,6 @@ use Mollie\OAuth2\Client\Provider\MollieResourceOwner;
 class MollieClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return MollieResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/OdnoklassnikiClient.php
+++ b/src/Client/Provider/OdnoklassnikiClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use Aego\OAuth2\Client\Provider\OdnoklassnikiResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use Aego\OAuth2\Client\Provider\OdnoklassnikiResourceOwner;
 
 class OdnoklassnikiClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return OdnoklassnikiResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/PaypalClient.php
+++ b/src/Client/Provider/PaypalClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\PaypalResourceOwner;
 class PaypalClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return PaypalResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/PsnClient.php
+++ b/src/Client/Provider/PsnClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use Larabros\OAuth2\Client\Provider\PsnResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
 
 class PsnClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return PsnResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/SalesforceClient.php
+++ b/src/Client/Provider/SalesforceClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\SalesforceResourceOwner;
 class SalesforceClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return SalesforceResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/SlackClient.php
+++ b/src/Client/Provider/SlackClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use AdamPaterson\OAuth2\Client\Provider\SlackResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use AdamPaterson\OAuth2\Client\Provider\SlackResourceOwner;
 
 class SlackClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return SlackResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/StravaClient.php
+++ b/src/Client/Provider/StravaClient.php
@@ -11,14 +11,12 @@
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
-use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\StravaResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
 
 class StravaClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return StravaResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/StripeClient.php
+++ b/src/Client/Provider/StripeClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use AdamPaterson\OAuth2\Client\Provider\StripeResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use AdamPaterson\OAuth2\Client\Provider\StripeResourceOwner;
 
 class StripeClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return StripeResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/UberClient.php
+++ b/src/Client/Provider/UberClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\UberResourceOwner;
 class UberClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return UberResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/UnsplashClient.php
+++ b/src/Client/Provider/UnsplashClient.php
@@ -17,8 +17,6 @@ use Unsplash\OAuth2\Client\Provide\UnsplashResourceOwner;
 class UnsplashClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return UnsplashResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/VKontakteClient.php
+++ b/src/Client/Provider/VKontakteClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
-use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use J4k\OAuth2\Client\Provider\User;
+use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
 
 class VKontakteClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return User|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/VimeoClient.php
+++ b/src/Client/Provider/VimeoClient.php
@@ -17,8 +17,6 @@ use Saf33r\OAuth2\Client\Provider\VimeoResourceOwner;
 class VimeoClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return VimeoResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/YahooClient.php
+++ b/src/Client/Provider/YahooClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use Hayageek\OAuth2\Client\Provider\YahooUser;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use Hayageek\OAuth2\Client\Provider\YahooUser;
 
 class YahooClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return YahooUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/YandexClient.php
+++ b/src/Client/Provider/YandexClient.php
@@ -10,15 +10,13 @@
 
 namespace KnpU\OAuth2ClientBundle\Client\Provider;
 
+use Aego\OAuth2\Client\Provider\YandexResourceOwner;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use League\OAuth2\Client\Token\AccessToken;
-use Aego\OAuth2\Client\Provider\YandexResourceOwner;
 
 class YandexClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return YandexResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/Client/Provider/ZendeskClient.php
+++ b/src/Client/Provider/ZendeskClient.php
@@ -17,8 +17,6 @@ use Stevenmaguire\OAuth2\Client\Provider\ZendeskResourceOwner;
 class ZendeskClient extends OAuth2Client
 {
     /**
-     * @param AccessToken $accessToken
-     *
      * @return ZendeskResourceOwner|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -65,12 +65,12 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\Config\FileLocator;
 
 class KnpUOAuth2ClientExtension extends Extension
 {
@@ -148,9 +148,6 @@ class KnpUOAuth2ClientExtension extends Extension
 
     /**
      * Load the bundle configuration.
-     *
-     * @param array            $configs
-     * @param ContainerBuilder $container
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -169,20 +166,13 @@ class KnpUOAuth2ClientExtension extends Extension
         foreach ($clientConfigurations as $key => $clientConfig) {
             // manually make sure "type" is there
             if (!isset($clientConfig['type'])) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Your "knpu_oauth2_client.clients.%s" config entry is missing the "type" key.',
-                    $key
-                ));
+                throw new InvalidConfigurationException(sprintf('Your "knpu_oauth2_client.clients.%s" config entry is missing the "type" key.', $key));
             }
 
             $type = $clientConfig['type'];
             unset($clientConfig['type']);
             if (!isset(self::$supportedProviderTypes[$type])) {
-                throw new InvalidConfigurationException(sprintf(
-                    'The "knpu_oauth2_client.clients" config "type" key "%s" is not supported. We support (%s)',
-                    $type,
-                    implode(', ', self::$supportedProviderTypes)
-                ));
+                throw new InvalidConfigurationException(sprintf('The "knpu_oauth2_client.clients" config "type" key "%s" is not supported. We support (%s)', $type, implode(', ', self::$supportedProviderTypes)));
             }
 
             // process the configuration
@@ -228,28 +218,22 @@ class KnpUOAuth2ClientExtension extends Extension
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param string           $providerType   The "type" used in the config - e.g. "facebook"
-     * @param string           $providerKey    The config key used for this - e.g. "facebook_client", "my_facebook"
-     * @param string           $providerClass  Provider class
-     * @param string           $clientClass    Class to use for the Client
-     * @param string           $packageName    Packagist package name required
-     * @param array            $options        Options passed to when constructing the provider
-     * @param string           $redirectRoute  Route name for the redirect URL
-     * @param array            $redirectParams Route params for the redirect URL
-     * @param bool             $useState
-     * @param array            $collaborators
+     * @param string $providerType   The "type" used in the config - e.g. "facebook"
+     * @param string $providerKey    The config key used for this - e.g. "facebook_client", "my_facebook"
+     * @param string $providerClass  Provider class
+     * @param string $clientClass    Class to use for the Client
+     * @param string $packageName    Packagist package name required
+     * @param array  $options        Options passed to when constructing the provider
+     * @param string $redirectRoute  Route name for the redirect URL
+     * @param array  $redirectParams Route params for the redirect URL
+     * @param bool   $useState
      *
      * @return string The client service id
      */
     private function configureProviderAndClient(ContainerBuilder $container, $providerType, $providerKey, $providerClass, $clientClass, $packageName, array $options, $redirectRoute, array $redirectParams, $useState, array $collaborators)
     {
         if ($this->checkExternalClassExistence && !class_exists($providerClass)) {
-            throw new \LogicException(sprintf(
-                'Run `composer require %s` in order to use the "%s" OAuth provider.',
-                $packageName,
-                $providerType
-            ));
+            throw new \LogicException(sprintf('Run `composer require %s` in order to use the "%s" OAuth provider.', $packageName, $providerType));
         }
 
         $providerServiceKey = sprintf('knpu.oauth2.provider.%s', $providerKey);

--- a/src/DependencyInjection/ProviderFactory.php
+++ b/src/DependencyInjection/ProviderFactory.php
@@ -24,8 +24,6 @@ class ProviderFactory
 
     /**
      * ProviderFactory constructor.
-     *
-     * @param UrlGeneratorInterface $generator
      */
     public function __construct(UrlGeneratorInterface $generator)
     {
@@ -36,10 +34,7 @@ class ProviderFactory
      * Creates a provider of the given class.
      *
      * @param string $class
-     * @param array  $options
      * @param string $redirectUri
-     * @param array  $redirectParams
-     * @param array  $collaborators
      *
      * @return mixed
      */

--- a/src/DependencyInjection/Providers/AppleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AppleProviderConfigurator.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;

--- a/src/DependencyInjection/Providers/AppleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AppleProviderConfigurator.php
@@ -4,19 +4,24 @@ namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
-class AppleProviderConfigurator implements ProviderConfiguratorInterface
+class AppleProviderConfigurator implements ProviderConfiguratorInterface, ProviderWithoutClientSecretConfiguratorInterface
 {
+    public function needsClientSecret(): bool
+    {
+        return false;
+    }
+
     public function buildConfiguration(NodeBuilder $node)
     {
         $node
             ->scalarNode('team_id')
-                ->cannotBeEmpty()
+                ->isRequired()
             ->end()
             ->scalarNode('key_file_id')
-                ->cannotBeEmpty()
+                ->isRequired()
             ->end()
             ->scalarNode('key_file_path')
-                ->cannotBeEmpty()
+                ->isRequired()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Providers/ProviderConfiguratorInterface.php
+++ b/src/DependencyInjection/Providers/ProviderConfiguratorInterface.php
@@ -17,14 +17,10 @@ interface ProviderConfiguratorInterface
     /**
      * Build the config tree for any *extra* options that you need
      * to configure your provider.
-     *
-     * @param NodeBuilder $node
      */
     public function buildConfiguration(NodeBuilder $node);
 
     /**
-     * @param array $configuration
-     *
      * @return string
      */
     public function getProviderClass(array $configuration);
@@ -35,15 +31,11 @@ interface ProviderConfiguratorInterface
      * Each provider should have their own, but you could
      * default to OAuth2Client.
      *
-     * @param array $config
-     *
      * @return string
      */
     public function getClientClass(array $config);
 
     /**
-     * @param array $configuration
-     *
      * @return array
      */
     public function getProviderOptions(array $configuration);

--- a/src/DependencyInjection/Providers/ProviderWithoutClientSecretConfiguratorInterface.php
+++ b/src/DependencyInjection/Providers/ProviderWithoutClientSecretConfiguratorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
+
+interface ProviderWithoutClientSecretConfiguratorInterface
+{
+    /**
+     * Implement and return false for any providers that do not
+     * require a "client_secret" - like apple.
+     */
+    public function needsClientSecret(): bool;
+}

--- a/src/DependencyInjection/Providers/ProviderWithoutClientSecretConfiguratorInterface.php
+++ b/src/DependencyInjection/Providers/ProviderWithoutClientSecretConfiguratorInterface.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * OAuth2 Client Bundle
+ * Copyright (c) KnpUniversity <http://knpuniversity.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
 interface ProviderWithoutClientSecretConfiguratorInterface

--- a/src/Security/Authenticator/SocialAuthenticator.php
+++ b/src/Security/Authenticator/SocialAuthenticator.php
@@ -10,18 +10,18 @@
 
 namespace KnpU\OAuth2ClientBundle\Security\Authenticator;
 
+use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 use KnpU\OAuth2ClientBundle\Exception\InvalidStateException;
+use KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException;
 use KnpU\OAuth2ClientBundle\Security\Exception\IdentityProviderAuthenticationException;
 use KnpU\OAuth2ClientBundle\Security\Exception\InvalidStateAuthenticationException;
 use KnpU\OAuth2ClientBundle\Security\Exception\NoAuthCodeAuthenticationException;
-use KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException;
 use KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior;
 use KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper;
 use KnpU\OAuth2ClientBundle\Security\Helper\SaveAuthFailureMessage;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
-use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 
 abstract class SocialAuthenticator extends AbstractGuardAuthenticator
 {

--- a/src/Security/Helper/FinishRegistrationBehavior.php
+++ b/src/Security/Helper/FinishRegistrationBehavior.php
@@ -24,9 +24,6 @@ trait FinishRegistrationBehavior
     /**
      * Call this from within your onAuthenticationFailure() method.
      *
-     * @param Request                     $request
-     * @param FinishRegistrationException $e
-     *
      * @throws LogicException
      */
     protected function saveUserInfoToSession(Request $request, FinishRegistrationException $e)
@@ -45,8 +42,6 @@ trait FinishRegistrationBehavior
 
     /**
      * Useful during registration to get your user information back out.
-     *
-     * @param Request $request
      *
      * @return mixed
      *

--- a/src/Security/Helper/PreviousUrlHelper.php
+++ b/src/Security/Helper/PreviousUrlHelper.php
@@ -18,8 +18,7 @@ trait PreviousUrlHelper
     /**
      * Returns the URL (if any) the user visited that forced them to login.
      *
-     * @param Request $request
-     * @param string  $providerKey
+     * @param string $providerKey
      *
      * @return string
      */

--- a/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
+++ b/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
@@ -152,6 +152,11 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
                 'redirect_params' => [],
                 'use_state' => rand(0, 1) == 0,
             ];
+
+            if (!KnpUOAuth2ClientExtension::configuratorNeedsClientSecret($configurator)) {
+                unset($config['client_secret']);
+            }
+
             // loop through and assign some random values
             foreach ($arrayNode->getChildren() as $child) {
                 /** @var NodeInterface $child */


### PR DESCRIPTION
Supports #221: the apple provider actually does *not* need a `client_secret`. This makes it possible for a provider configurator to remove that.