### PR TITLE
Allow to pass options when fetching access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/*
 /tests/app/cache
 /.php_cs.cache
+/.phpunit.result.cache

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -80,6 +80,8 @@ class OAuth2Client implements OAuth2ClientInterface
     /**
      * Call this after the user is redirected back to get the access token.
      *
+     * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
+     *
      * @return AccessToken|\League\OAuth2\Client\Token\AccessTokenInterface
      *
      * @throws InvalidStateException

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -86,7 +86,7 @@ class OAuth2Client implements OAuth2ClientInterface
      * @throws MissingAuthorizationCodeException
      * @throws IdentityProviderException         If token cannot be fetched
      */
-    public function getAccessToken()
+    public function getAccessToken(array $options = [])
     {
         if (!$this->isStateless) {
             $expectedState = $this->getSession()->get(self::OAUTH2_SESSION_STATE_KEY);
@@ -102,9 +102,10 @@ class OAuth2Client implements OAuth2ClientInterface
             throw new MissingAuthorizationCodeException('No "code" parameter was found (usually this is a query parameter)!');
         }
 
-        return $this->provider->getAccessToken('authorization_code', [
-            'code' => $code,
-        ]);
+        return $this->provider->getAccessToken(
+            'authorization_code',
+            array_merge(['code' => $code], $options)
+        );
     }
 
     /**

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -39,7 +39,7 @@ interface OAuth2ClientInterface
      * @throws \KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException   If token cannot be fetched
      */
-    public function getAccessToken();
+    public function getAccessToken(array $options = []);
 
     /**
      * Returns the "User" information (called a resource owner).

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -33,6 +33,8 @@ interface OAuth2ClientInterface
     /**
      * Call this after the user is redirected back to get the access token.
      *
+     * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
+     *
      * @return \League\OAuth2\Client\Token\AccessToken
      *
      * @throws \KnpU\OAuth2ClientBundle\Exception\InvalidStateException

--- a/src/Security/Authenticator/SocialAuthenticator.php
+++ b/src/Security/Authenticator/SocialAuthenticator.php
@@ -29,10 +29,10 @@ abstract class SocialAuthenticator extends AbstractGuardAuthenticator
     use PreviousUrlHelper;
     use SaveAuthFailureMessage;
 
-    protected function fetchAccessToken(OAuth2ClientInterface $client)
+    protected function fetchAccessToken(OAuth2ClientInterface $client, array $options = [])
     {
         try {
-            return $client->getAccessToken();
+            return $client->getAccessToken($options);
         } catch (MissingAuthorizationCodeException $e) {
             throw new NoAuthCodeAuthenticationException();
         } catch (IdentityProviderException $e) {

--- a/tests/Client/OAuth2ClientTest.php
+++ b/tests/Client/OAuth2ClientTest.php
@@ -137,6 +137,26 @@ class OAuth2ClientTest extends TestCase
         $this->assertSame($expectedToken->reveal(), $actualToken);
     }
 
+    public function testGetAccessTokenWithOptions()
+    {
+        $this->request->query->set('state', 'THE_STATE');
+        $this->request->query->set('code', 'CODE_ABC');
+
+        $this->session->get(OAuth2Client::OAUTH2_SESSION_STATE_KEY)
+            ->willReturn('THE_STATE');
+
+        $expectedToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
+        $this->provider->getAccessToken('authorization_code', ['code' => 'CODE_ABC', 'redirect_uri' => 'https://some.url'])
+            ->willReturn($expectedToken->reveal());
+
+        $client = new OAuth2Client(
+            $this->provider->reveal(),
+            $this->requestStack
+        );
+        $actualToken = $client->getAccessToken(['redirect_uri' => 'https://some.url']);
+        $this->assertSame($expectedToken->reveal(), $actualToken);
+    }
+
     public function testGetAccessTokenFromPOST()
     {
         $this->request->request->set('code', 'CODE_ABC');

--- a/tests/Security/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/Security/Authenticator/SocialAuthenticatorTest.php
@@ -28,7 +28,7 @@ class SocialAuthenticatorTest extends TestCase
     {
         $authenticator = new StubSocialAuthenticator();
         $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken()
+        $client->getAccessToken([])
             ->willReturn('expected_access_token');
 
         $actualToken = $authenticator->doFetchAccessToken($client->reveal());
@@ -40,7 +40,7 @@ class SocialAuthenticatorTest extends TestCase
         $this->expectException(NoAuthCodeAuthenticationException::class);
         $authenticator = new StubSocialAuthenticator();
         $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken()
+        $client->getAccessToken([])
             ->willThrow(new MissingAuthorizationCodeException());
 
         $authenticator->doFetchAccessToken($client->reveal());


### PR DESCRIPTION
This little change allow to pass `options` when fetching `AccessToken`. 

### Motivation
Some providers checks for `redirect_uri` when fetching token from `code` (last step). When in my app is more than one entry point with otuah (for example different scopes in different app region) I want to have ability to change `redirect_uri`. The `redirect` method allows for that, but then, when user returns from provider `redirect_uri` param is taken from main configuration, which causes auth error (i.e. GitLab). For now the only solution is:
```
        gitlab-register:
            type: gitlab
            client_id: '%env(OAUTH_GITLAB_CLIENT_ID)%'
            client_secret: '%env(OAUTH_GITLAB_CLIENT_SECRET)%'
            redirect_route: register_gitlab_check
        gitlab-auth:
            type: gitlab
            client_id: '%env(OAUTH_GITLAB_CLIENT_ID)%'
            client_secret: '%env(OAUTH_GITLAB_CLIENT_SECRET)%'
            redirect_route: login_gitlab_check
```

This PR allow to have one client and change only `redirect_uri`:

```php
// Start -> redirect
$this->oauth->getClient('gitlab')->redirect(['read_user'], ['redirect_uri' => 'https://some.url'])

// Return -> check
$this->oauth->getClient('gitlab')->getAccessToken(['redirect_uri' => 'https://some.url']);
```