### PR TITLE
Adding OAuth2Client::isStateless() hook point

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
-        "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/routing": "^3.4|^4.0|^5.0",
-        "symfony/http-foundation": "^3.4|^4.0|^5.0",
+        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/dependency-injection": "^4.4|^5.0",
+        "symfony/routing": "^4.4|^5.0",
+        "symfony/http-foundation": "^4.4|^5.0",
         "league/oauth2-client": "^1.0|^2.0"
     },
     "autoload": {
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1|^2.0",
-        "symfony/phpunit-bridge": "^4.3|^5.0",
-        "symfony/security-guard": "^3.4|^4.0|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0",
+        "symfony/security-guard": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0",
         "phpspec/prophecy": "^1.8",
         "phpstan/phpstan": "^0.11.16"
     },

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -67,7 +67,7 @@ class OAuth2Client implements OAuth2ClientInterface
         $url = $this->provider->getAuthorizationUrl($options);
 
         // set the state (unless we're stateless)
-        if (!$this->isStateless) {
+        if (!$this->isStateless()) {
             $this->getSession()->set(
                 self::OAUTH2_SESSION_STATE_KEY,
                 $this->provider->getState()
@@ -90,7 +90,7 @@ class OAuth2Client implements OAuth2ClientInterface
      */
     public function getAccessToken(array $options = [])
     {
-        if (!$this->isStateless) {
+        if (!$this->isStateless()) {
             $expectedState = $this->getSession()->get(self::OAUTH2_SESSION_STATE_KEY);
             $actualState = $this->getCurrentRequest()->query->get('state');
             if (!$actualState || ($actualState !== $expectedState)) {
@@ -144,6 +144,11 @@ class OAuth2Client implements OAuth2ClientInterface
     public function getOAuth2Provider()
     {
         return $this->provider;
+    }
+
+    protected function isStateless(): bool
+    {
+        return $this->isStateless;
     }
 
     /**


### PR DESCRIPTION
Fixes #232

This also drops support for older Symfony versions. This will be for v2.

TODO: Add a CHANGELOG.