### PR TITLE
List required symfony version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This bundle integrates with [league/oauth2-client](http://oauth2-client.thephple
 ## Requirements
 
 * PHP 7.1.3 or higher
-* Symfony 4.4 or higher
+* Symfony 4.4 or higher (use version 1 of the bundle for earlier support)
 
 ## This bundle or HWIOAuthBundle?
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This bundle integrates with [league/oauth2-client](http://oauth2-client.thephple
 ## Requirements
 
 * PHP 7.1.3 or higher
+* Symfony 4.4 or higher
 
 ## This bundle or HWIOAuthBundle?
 


### PR DESCRIPTION
I have symfony 4.3, so can't install this package and i only saw there was a minimum version during composer install :(