### PR TITLE
Added support for endpoint version on Azure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ knpu_oauth2_client:
             # api_version: '1.6'
             # Send resource field with auth-request
             # auth_with_resource: true
+            # The endpoint version to run against
+            # default_end_point_version: '1.0'
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 

--- a/src/DependencyInjection/Providers/AzureProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AzureProviderConfigurator.php
@@ -58,6 +58,11 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface
                 ->example('auth_with_resource: true')
                 ->info('Send resource field with auth-request')
                 ->defaultTrue()
+            ->end()
+            ->scalarNode('default_end_point_version')
+                ->example("default_end_point_version: '1.0'")
+                ->info('The endpoint version to run against')
+                ->defaultValue('1.0')
             ->end();
     }
 
@@ -80,6 +85,7 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface
             'resource' => $config['resource'],
             'API_VERSION' => $config['api_version'],
             'authWithResource' => $config['auth_with_resource'],
+            'defaultEndPointVersion' => $config['default_end_point_version'],
         ];
     }
 


### PR DESCRIPTION
With this release https://github.com/TheNetworg/oauth2-azure/releases/tag/v2.0.0, we gain the support for v2.0 of Azure endpoints (see https://github.com/TheNetworg/oauth2-azure/pull/76).
One thing that's missing with this bundle, is the chance to set the default_end_point_version in order to switch from 1 to 2.
I've done this little PR in order to make it possible.
Is worthy to notice that I've left `1.0` as `default_end_point_version value` in order to not introduce a BC break (with `TheNetworg/oauth2-azure` we use to go directly on 1.0).

WDYT?