### PR TITLE
Add support for refreshToken()

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ If you store your access tokens for use at a later time, you should check that i
 If it is expired, you can easily refresh it:
 
 ```php
-// Load the access token from wherever you have store it (eg. user session, database, etc)
+// Load the access token from persistence (eg. user session, database, etc)
 $accessToken = $tokenStorage->retrieveAccessToken();
 
 if ($accessToken->hasExpired()) {

--- a/README.md
+++ b/README.md
@@ -430,6 +430,29 @@ public function getUser($credentials, UserProviderInterface $userProvider)
 The logged-in user will be an instance of `KnpU\OAuth2ClientBundle\Security\User\OAuthUser` and will
 have the roles `ROLE_USER` and `ROLE_OAUTH_USER`.
 
+## Refresh Tokens
+
+If you store your access tokens for use at a later time, you should check that it's not expired before you use it again.
+If it is expired, you can easily refresh it:
+
+```php
+// Load the access token from wherever you have store it (eg. user session, database, etc)
+$accessToken = $tokenStorage->retrieveAccessToken();
+
+if ($accessToken->hasExpired()) {
+    $accessToken = $client->refreshAccessToken($accessToken);
+
+    // Update the stored access token for next time
+    $tokenStorage->updateAccessToken($accesStoken);
+}
+```
+
+Depending on your OAuth2 provider, you may need to pass some parameters when refreshing the token:
+
+```php
+$accessToken = $client->refreshAccessToken($accessToken, ['scopes' => 'offline_access']);
+```
+
 ## Configuration
 
 Below is the configuration for *all* of the supported OAuth2 providers.

--- a/README.md
+++ b/README.md
@@ -444,14 +444,15 @@ You have a couple of options to store access tokens for use at a later time:
     $accessToken = $session->get('access_token');
 
     if ($accessToken->hasExpired()) {
-        $accessToken = $client->refreshAccessToken($accessToken);
+        $accessToken = $client->refreshAccessToken($accessToken->getRefreshToken);
 
         // Update the stored access token for next time
         $session->set('access_token', $accessToken);
     }
     ```
 
-2. Store just the refresh token string (eg. in the dabatase `user.refresh_token`), this means you must always refresh
+2. Store the refresh token string (eg. in the dabatase `user.refresh_token`), this means you must always refresh. 
+    You can also store the access token and expiration and then avoid the refresh until the access token is actually expired.
     ```php
     // Fetch the AccessToken and store the refresh token
     $accessToken = $client->getAccessToken();
@@ -464,10 +465,14 @@ You have a couple of options to store access tokens for use at a later time:
     $entityManager->flush();
 ```
 
-Depending on your OAuth2 provider, you may need to pass some parameters when refreshing the token:
+Depending on your OAuth2 provider, you may need to pass some parameters when initially creating and/or refreshing the token:
 
 ```php
-$accessToken = $client->refreshAccessToken($accessToken, ['scopes' => 'offline_access']);
+// Some providers may require special parameters when creating the token in order to allow refreshing
+$accessToken = $client->getAccessToken(['scopes' => 'offline_access']);
+
+// They may also require special parameters when refreshing the token
+$accessToken = $client->refreshAccessToken($accessToken->getRefreshtoken(), ['scopes' => 'offline_access']);
 ```
 
 ## Configuration

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -15,7 +15,6 @@ use KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
-use League\OAuth2\Client\Token\AccessTokenInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -114,7 +114,7 @@ class OAuth2Client implements OAuth2ClientInterface
     }
 
     /**
-     * Refresh the given AccessToken.
+     * Get a new AccessToken from a refresh token.
      *
      * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
      *
@@ -122,11 +122,11 @@ class OAuth2Client implements OAuth2ClientInterface
      *
      * @throws IdentityProviderException If token cannot be fetched
      */
-    public function refreshAccessToken(AccessTokenInterface $accessToken, array $options = [])
+    public function refreshAccessToken(string $refreshToken, array $options = [])
     {
         return $this->provider->getAccessToken(
             'refresh_token',
-            array_merge(['refresh_token' => $accessToken->getRefreshToken()], $options)
+            array_merge(['refresh_token' => $refreshToken], $options)
         );
     }
 

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -15,6 +15,7 @@ use KnpU\OAuth2ClientBundle\Exception\MissingAuthorizationCodeException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -109,6 +110,23 @@ class OAuth2Client implements OAuth2ClientInterface
         return $this->provider->getAccessToken(
             'authorization_code',
             array_merge(['code' => $code], $options)
+        );
+    }
+
+    /**
+     * Refresh the given AccessToken.
+     *
+     * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
+     *
+     * @return AccessToken|\League\OAuth2\Client\Token\AccessTokenInterface
+     *
+     * @throws IdentityProviderException If token cannot be fetched
+     */
+    public function refreshAccessToken(AccessTokenInterface $accessToken, array $options = [])
+    {
+        return $this->provider->getAccessToken(
+            'refresh_token',
+            array_merge(['refresh_token' => $accessToken->getRefreshToken()], $options)
         );
     }
 

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -11,7 +11,6 @@
 namespace KnpU\OAuth2ClientBundle\Client;
 
 use League\OAuth2\Client\Token\AccessToken;
-use League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
  * @method AccessToken refreshAccessToken(string $refreshToken, array $options = []) Get a new AccessToken from a refresh token., passing options to the underlying provider

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -10,7 +10,6 @@
 
 namespace KnpU\OAuth2ClientBundle\Client;
 
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -10,7 +10,9 @@
 
 namespace KnpU\OAuth2ClientBundle\Client;
 
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 
 interface OAuth2ClientInterface
 {
@@ -44,6 +46,17 @@ interface OAuth2ClientInterface
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException   If token cannot be fetched
      */
     public function getAccessToken(array $options = []);
+
+    /**
+     * Refresh the given AccessToken.
+     *
+     * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
+     *
+     * @return AccessToken|\League\OAuth2\Client\Token\AccessTokenInterface
+     *
+     * @throws IdentityProviderException If token cannot be fetched
+     */
+    public function refreshAccessToken(AccessTokenInterface $accessToken, array $options = []);
 
     /**
      * Returns the "User" information (called a resource owner).

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -14,6 +14,9 @@ use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 
+/**
+ * @method AccessToken refreshAccessToken(AccessTokenInterface $accessToken, array $options = []) Refresh the access token, passing options to the underlying provider
+ */
 interface OAuth2ClientInterface
 {
     /**
@@ -46,17 +49,6 @@ interface OAuth2ClientInterface
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException   If token cannot be fetched
      */
     public function getAccessToken(array $options = []);
-
-    /**
-     * Refresh the given AccessToken.
-     *
-     * @param array $options Additional options that should be passed to the getAccessToken() of the underlying provider
-     *
-     * @return AccessToken|\League\OAuth2\Client\Token\AccessTokenInterface
-     *
-     * @throws IdentityProviderException If token cannot be fetched
-     */
-    public function refreshAccessToken(AccessTokenInterface $accessToken, array $options = []);
 
     /**
      * Returns the "User" information (called a resource owner).

--- a/src/Client/OAuth2ClientInterface.php
+++ b/src/Client/OAuth2ClientInterface.php
@@ -14,7 +14,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
- * @method AccessToken refreshAccessToken(AccessTokenInterface $accessToken, array $options = []) Refresh the access token, passing options to the underlying provider
+ * @method AccessToken refreshAccessToken(string $refreshToken, array $options = []) Get a new AccessToken from a refresh token., passing options to the underlying provider
  */
 interface OAuth2ClientInterface
 {

--- a/tests/Client/OAuth2ClientTest.php
+++ b/tests/Client/OAuth2ClientTest.php
@@ -188,7 +188,7 @@ class OAuth2ClientTest extends TestCase
             $this->provider->reveal(),
             $this->requestStack
         );
-        $actualToken = $client->refreshAccessToken($existingToken->reveal());
+        $actualToken = $client->refreshAccessToken($existingToken->reveal()->getRefreshToken());
         $this->assertSame($expectedToken->reveal(), $actualToken);
     }
 
@@ -205,7 +205,7 @@ class OAuth2ClientTest extends TestCase
             $this->provider->reveal(),
             $this->requestStack
         );
-        $actualToken = $client->refreshAccessToken($existingToken->reveal(), ['redirect_uri' => 'https://some.url']);
+        $actualToken = $client->refreshAccessToken($existingToken->reveal()->getRefreshToken(), ['redirect_uri' => 'https://some.url']);
         $this->assertSame($expectedToken->reveal(), $actualToken);
     }
 

--- a/tests/Client/OAuth2ClientTest.php
+++ b/tests/Client/OAuth2ClientTest.php
@@ -175,6 +175,40 @@ class OAuth2ClientTest extends TestCase
         $this->assertSame($expectedToken->reveal(), $actualToken);
     }
 
+    public function testRefreshAccessToken()
+    {
+        $existingToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
+        $existingToken->getRefreshToken()->willReturn('TOKEN_ABC');
+
+        $expectedToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
+        $this->provider->getAccessToken('refresh_token', ['refresh_token' => 'TOKEN_ABC'])
+            ->willReturn($expectedToken->reveal());
+
+        $client = new OAuth2Client(
+            $this->provider->reveal(),
+            $this->requestStack
+        );
+        $actualToken = $client->refreshAccessToken($existingToken->reveal());
+        $this->assertSame($expectedToken->reveal(), $actualToken);
+    }
+
+    public function testRefreshAccessTokenWithOptions()
+    {
+        $existingToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
+        $existingToken->getRefreshToken()->willReturn('TOKEN_ABC');
+
+        $expectedToken = $this->prophesize('League\OAuth2\Client\Token\AccessToken');
+        $this->provider->getAccessToken('refresh_token', ['refresh_token' => 'TOKEN_ABC', 'redirect_uri' => 'https://some.url'])
+            ->willReturn($expectedToken->reveal());
+
+        $client = new OAuth2Client(
+            $this->provider->reveal(),
+            $this->requestStack
+        );
+        $actualToken = $client->refreshAccessToken($existingToken->reveal(), ['redirect_uri' => 'https://some.url']);
+        $this->assertSame($expectedToken->reveal(), $actualToken);
+    }
+
     public function testGetAccessTokenThrowsInvalidStateException()
     {
         $this->expectException(InvalidStateException::class);


### PR DESCRIPTION
As discussed in #260, it would be great to have native support to refresh access tokens. I'm successfully using this in my Symfony 4.4 application.

Closes: #260 