### PR TITLE
Adds a default value to azure api_version

### DIFF
--- a/src/DependencyInjection/Providers/AzureProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AzureProviderConfigurator.php
@@ -53,6 +53,7 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface
             ->scalarNode('api_version')
                 ->example("api_version: '1.6'")
                 ->info('The API version to run against')
+                ->defaultValue('1.6')
             ->end()
             ->booleanNode('auth_with_resource')
                 ->example('auth_with_resource: true')


### PR DESCRIPTION
I don't know much about this provider, but this value should either be required or have a default. It appears that the underlying library defaults to 1.6 - https://github.com/TheNetworg/oauth2-azure/blob/0d28aaa681d1044525418c27843f65d7946f67c6/src/Provider/Azure.php#L38