### PR TITLE
Fixing access token, which becomes a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,12 +473,13 @@ class MyFacebookAuthenticator extends OAuth2Authenticator
 
     public function authenticate(Request $request): PassportInterface
     {
-        $accessToken = $this->fetchAccessToken($this->clientRegistry->getClient('facebook_main'));
+        $client = $this->clientRegistry->getClient('facebook_main');
+        $accessToken = $this->fetchAccessToken($client);
 
         return new SelfValidatingPassport(
-            new UserBadge($accessToken, function() {
+            new UserBadge($accessToken, function() use ($accessToken, $client) {
                 /** @var FacebookUser $facebookUser */
-                $facebookUser = $this->clientRegistry->getClient('facebook_main')->fetchUserFromToken($accessToken);
+                $facebookUser = $client->fetchUserFromToken($accessToken);
 
                 $email = $facebookUser->getEmail();
 

--- a/README.md
+++ b/README.md
@@ -473,12 +473,12 @@ class MyFacebookAuthenticator extends OAuth2Authenticator
 
     public function authenticate(Request $request): PassportInterface
     {
-        $credentials = $this->fetchAccessToken($this->clientRegistry->getClient('facebook_main'));
+        $accessToken = $this->fetchAccessToken($this->clientRegistry->getClient('facebook_main'));
 
         return new SelfValidatingPassport(
-            new UserBadge($credentials, function($credentials) {
+            new UserBadge($accessToken, function() {
                 /** @var FacebookUser $facebookUser */
-                $facebookUser = $this->clientRegistry->getClient('facebook_main')->fetchUserFromToken($credentials);
+                $facebookUser = $this->clientRegistry->getClient('facebook_main')->fetchUserFromToken($accessToken);
 
                 $email = $facebookUser->getEmail();
 


### PR DESCRIPTION
Renamed $credentials -> $accessToken for clarity.

Also, use $accessToken from the original authenticate() method, instead of the argument that's passed to the callback, because that will have been cast into just the access token string.

See: https://github.com/knpuniversity/oauth2-client-bundle/pull/292#issuecomment-825110798