### PR TITLE
[ci] drop FlintCI from CI

### DIFF
--- a/.flintci.yml
+++ b/.flintci.yml
@@ -1,3 +1,0 @@
-services:
-  phpcsfixer:
-    version: 2


### PR DESCRIPTION
It does not appear FlintCI is being maintained anymore based on the activity in the GitLab repo. Furthermore, with GitHub Actions - additional CI just complicates life.

- [ ] Disable FlintCI in repo settings