### PR TITLE
Allowing PHP 8 within composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.1.3|^8.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/routing": "^4.4|^5.0",


### PR DESCRIPTION
Solves #318 

No direct dependency conflicts noticed while installing. Also cannot find any non strict checks ` == ` that are actually used in code. So I trust we should not have issues there.

Yes oauth2-client-bundle may still need a rewrite to completely go to php 8 but this is a start for projects that want to update :)

