### PR TITLE
Fixing bug in docs giving AccessToken instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ class MyFacebookAuthenticator extends OAuth2Authenticator
         $accessToken = $this->fetchAccessToken($client);
 
         return new SelfValidatingPassport(
-            new UserBadge($accessToken, function() use ($accessToken, $client) {
+            new UserBadge($accessToken->getToken(), function() use ($accessToken, $client) {
                 /** @var FacebookUser $facebookUser */
                 $facebookUser = $client->fetchUserFromToken($accessToken);
 


### PR DESCRIPTION
Using the code in the README throws an error.

> Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge::__construct(): Argument #1 ($userIdentifier) must be of type string, League\OAuth2\Client\Token\AccessToken given, called in /home/app/web/src/Security/GoogleAuthenticator.php on line 89

This fixes the issue.