### PR TITLE
Fix TwitchClient PHPDoc to suppress PHPStan errors

### DIFF
--- a/src/Client/Provider/TwitchClient.php
+++ b/src/Client/Provider/TwitchClient.php
@@ -17,7 +17,7 @@ use League\OAuth2\Client\Token\AccessToken;
 class TwitchClient extends OAuth2Client
 {
     /**
-     * @return TwitchUser
+     * @return TwitchUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUserFromToken(AccessToken $accessToken)
     {
@@ -25,7 +25,7 @@ class TwitchClient extends OAuth2Client
     }
 
     /**
-     * @return TwitchUser
+     * @return TwitchUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     public function fetchUser()
     {


### PR DESCRIPTION
Fixes these PHPStan errors:

> Error: Method KnpU\OAuth2ClientBundle\Client\Provider\TwitchClient::fetchUserFromToken() should return Depotwarehouse\OAuth2\Client\Twitch\Entity\TwitchUser but returns League\OAuth2\Client\Provider\ResourceOwnerInterface.
> Error: Method KnpU\OAuth2ClientBundle\Client\Provider\TwitchClient::fetchUser() should return Depotwarehouse\OAuth2\Client\Twitch\Entity\TwitchUser but returns League\OAuth2\Client\Provider\ResourceOwnerInterface.

See related build: https://github.com/knpuniversity/oauth2-client-bundle/runs/3230174629