### PR TITLE
Removed some deprecations introduced in Symfony 5.*

### DIFF
--- a/src/Security/User/OAuthUser.php
+++ b/src/Security/User/OAuthUser.php
@@ -38,6 +38,14 @@ class OAuthUser implements UserInterface
         return null;
     }
 
+    public function getUserIdentifier(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @deprecated use getUserIdentifier instead
+     */
     public function getUsername(): string
     {
         return $this->username;

--- a/tests/Security/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/Security/Authenticator/SocialAuthenticatorTest.php
@@ -127,11 +127,16 @@ class SomeUser implements UserInterface
     {
     }
 
+    // to be removed when Symfony 6 is supported
     public function getUsername(): string
     {
     }
 
     public function eraseCredentials()
+    {
+    }
+
+    public function getUserIdentifier(): string
     {
     }
 }

--- a/tests/Security/User/OAuthUserTest.php
+++ b/tests/Security/User/OAuthUserTest.php
@@ -42,4 +42,11 @@ class OAuthUserTest extends TestCase
 
         $this->assertSame('username', $user->getUsername());
     }
+
+    public function testUserIdentifier()
+    {
+        $user = new OAuthUser('username', ['role 1', 'role 2']);
+
+        $this->assertSame('username', $user->getUserIdentifier());
+    }
 }

--- a/tests/app/TestKernel.php
+++ b/tests/app/TestKernel.php
@@ -41,6 +41,7 @@ class TestKernel extends Kernel
                 'secret' => 'this is a cool bundle. Shhh..., it\'s a secret...',
                 'router' => [
                     'resource' => __DIR__ . '/routing.yml',
+                    'utf8' => true,
                 ],
                 // turn this off - otherwise we need doctrine/annotation
                 // the change that required this was in Symfony 3.2.0


### PR DESCRIPTION
With this, we should get rid of deprecations introduced with symfony 5.*
I've checked all the changelogs and latest test https://github.com/knpuniversity/oauth2-client-bundle/runs/3484375665
We should be compliant.