### PR TITLE
Add PHP 8.1 to GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
                     - '7.3'
                     - '7.4'
                     - '8.0'
+                    - '8.1'
 
         name: PHP ${{ matrix.php }} ${{ matrix.description }}
         steps:


### PR DESCRIPTION
As PHP 8.1 will be out shortly and since this bundle claims to support a vast range oh PHP versions, I think it's good to add a build for PHP 8.1 also.