### PR TITLE
Enhancing test matrix, Symfony 6 support, dropping PHP 7.1, client 1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,41 +1,49 @@
-name: OAuth2 Client Tests
-
+name: Bundle CI
 on:
-    pull_request:
-    push:
-        branches: [ master ]
+  push:
+    branches: ['main']
+  pull_request:
+  schedule:
+    - cron: '0 */12 * * *'
 
 jobs:
-    run:
-        runs-on: ubuntu-18.04
-        strategy:
-            fail-fast: false
-            matrix:
-                php:
-                    - '7.1'
-                    - '7.2'
-                    - '7.3'
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
 
-        name: PHP ${{ matrix.php }} ${{ matrix.description }}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+  tests:
+    name: "Tests ${{ matrix.php-version }} ${{ matrix.dependency-versions }} deps ${{ matrix.dependency-versions }}"
+    runs-on: ubuntu-18.04
 
-            - uses: actions/cache@v2
-              with:
-                  path: ~/.composer/cache/files
-                  key: ${{ matrix.php }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # normal, highest, non-dev installs
+        php-version: ['7.3', '7.4', '8.0', '8.1']
+        composer-options: ['--prefer-stable']
+        dependency-versions: ['highest']
+        include:
+          # testing lowest php with lowest dependencies
+          - php-version: '7.2'
+            dependency-versions: 'lowest'
+            composer-options: '--prefer-lowest'
+          # testing dev versions with highest PHP
+          - php-version: '8.0'
+            dependency-versions: 'highest'
+            composer-options: '' # allow dev deps
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
 
-            - name: Install dependencies
-              run: composer install
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+            coverage: "none"
+            php-version: "${{ matrix.php-version }}"
 
-            - name: Run PHPUnit tests
-              run: ./vendor/bin/simple-phpunit
+      - name: "Composer install"
+        uses: "ramsey/composer-install@v1"
+        with:
+            dependency-versions: "${{ matrix.dependency-versions }}"
+            composer-options: "--prefer-dist --no-progress"
+
+      - name: Run PHPUnit tests
+        run: "SYMFONY_PHPUNIT_VERSION=${{ matrix.phpunit-version }} ./vendor/bin/simple-phpunit"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -26,11 +26,11 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
 
-            - name: Install dependencies
-              run: composer install
+            - name: Install PHP-CS-Fixer
+              run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress
 
             - name: Run script
-              run: vendor/bin/php-cs-fixer  fix --verbose --diff --dry-run
+              run: $HOME/.composer/vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
 
     phpstan:
         name: PHPStan
@@ -42,7 +42,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  key: '7.3'
+                  php-version: '8.0'
 
             - name: Install dependencies
               run: composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 *We intend to follow [Semantic Versioning 2.0.0](https://semver.org/), if you
 find a change that break's semver, please create an issue.*
 
+## [v2.9.0](https://github.com/symfony/maker-bundle/releases/tag/v2.9.0)
+
+*Nov 21st, 2021*
+
+### Feature
+
+- [#341](https://github.com/knpuniversity/oauth2-client-bundle/pull/341) - Enhancing test matrix, Symfony 6 support, dropping PHP 7.1, client 1.0 - *@weaverryan*
+- [#330](https://github.com/knpuniversity/oauth2-client-bundle/pull/330) - add symfony 6 return types - *@jrushlow*
+- [#335](https://github.com/knpuniversity/oauth2-client-bundle/pull/335) - Removed some deprecations introduced in Symfony 5.x - *@DonCallisto*
+- [#310](https://github.com/knpuniversity/oauth2-client-bundle/pull/310) - Adding FusionAuth provider - *@mooreds*
+
+### Bug Fix
+
+- [#309](https://github.com/knpuniversity/oauth2-client-bundle/pull/309) - Update TwitchClient configuration - *@chypriote*
+
 ## [v2.8.0](https://github.com/symfony/maker-bundle/releases/tag/v2.8.0)
 
 *March 23rd, 2021*

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
-use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
 class MyFacebookAuthenticator extends OAuth2Authenticator
@@ -472,7 +472,7 @@ class MyFacebookAuthenticator extends OAuth2Authenticator
         return $request->attributes->get('_route') === 'connect_facebook_check';
     }
 
-    public function authenticate(Request $request): PassportInterface
+    public function authenticate(Request $request): Passport
     {
         $client = $this->clientRegistry->getClient('facebook_main');
         $accessToken = $this->fetchAccessToken($client);
@@ -996,19 +996,19 @@ knpu_oauth2_client:
             # whether to check OAuth2 "state": defaults to true
             # use_state: true
 
-        # will create service: "knpu.oauth2.client.fusionauth"
+        # will create service: "knpu.oauth2.client.fusion_auth"
         # an instance of: KnpU\OAuth2ClientBundle\Client\Provider\FusionAuthClient
         # composer require jerryhopper/oauth2-fusionauth
         fusion_auth:
             # must be "fusion_auth" - it activates that type!
             type: fusion_auth
             # add and set these environment variables in your .env files
-            client_id: '%env(OAUTH_FUSIONAUTH_CLIENT_ID)%'
-            client_secret: '%env(OAUTH_FUSIONAUTH_CLIENT_SECRET)%'
+            client_id: '%env(OAUTH_FUSION_AUTH_CLIENT_ID)%'
+            client_secret: '%env(OAUTH_FUSION_AUTH_CLIENT_SECRET)%'
             # a route name you'll create
             redirect_route: connect_fusion_auth_check
             redirect_params: {}
-            # FusionAuth server URL, like http://localhost:9011
+            # FusionAuth Server URL, no trailing slash
             auth_server_url: null
             # whether to check OAuth2 "state": defaults to true
             # use_state: true

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["oauth", "oauth2"],
     "homepage": "https://symfonycasts.com",
     "license": "MIT",
+    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Ryan Weaver",
@@ -12,12 +13,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "symfony/framework-bundle": "^4.4|^5.0",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/routing": "^4.4|^5.0",
-        "symfony/http-foundation": "^4.4|^5.0",
-        "league/oauth2-client": "^1.0|^2.0"
+        "php": ">=7.2.5",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+        "symfony/routing": "^4.4|^5.0|^6.0",
+        "symfony/http-foundation": "^4.4|^5.0|^6.0",
+        "league/oauth2-client": "^2.0"
     },
     "autoload": {
         "psr-4": { "KnpU\\OAuth2ClientBundle\\": "src/" }
@@ -27,12 +28,10 @@
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1|^2.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0",
-        "symfony/security-guard": "^4.4|^5.0",
-        "symfony/yaml": "^4.4|^5.0",
-        "phpspec/prophecy": "^1.8",
-        "phpstan/phpstan": "^0.12",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "symfony/phpunit-bridge": "^5.3.1|^6.0",
+        "symfony/security-guard": "^4.4|^5.0|^6.0",
+        "symfony/yaml": "^4.4|^5.0|^6.0",
+        "phpstan/phpstan": "^0.12"
     },
     "suggest": {
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="baselineFile=./tests/allowed.json&amp;max[self]=0" />
     </php>
 
     <testsuites>

--- a/src/Security/Exception/IdentityProviderAuthenticationException.php
+++ b/src/Security/Exception/IdentityProviderAuthenticationException.php
@@ -28,7 +28,7 @@ class IdentityProviderAuthenticationException extends AuthenticationException
         return 'Error fetching OAuth credentials: "%error%".';
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return [
             '%error%' => $this->getMessage(),

--- a/src/Security/User/OAuthUser.php
+++ b/src/Security/User/OAuthUser.php
@@ -23,7 +23,7 @@ class OAuthUser implements UserInterface
         $this->roles = $roles;
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
         return $this->roles;
     }

--- a/src/Security/User/OAuthUserProvider.php
+++ b/src/Security/User/OAuthUserProvider.php
@@ -25,7 +25,12 @@ class OAuthUserProvider implements UserProviderInterface
 
     public function loadUserByUsername($username): UserInterface
     {
-        return new OAuthUser($username, $this->roles);
+        return $this->loadUserByIdentifier($username);
+    }
+
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        return new OAuthUser($identifier, $this->roles);
     }
 
     public function refreshUser(UserInterface $user): UserInterface
@@ -34,7 +39,9 @@ class OAuthUserProvider implements UserProviderInterface
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 
-        return $this->loadUserByUsername($user->getUsername());
+        return $this->loadUserByUsername(
+            method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername()
+        );
     }
 
     public function supportsClass($class): bool

--- a/tests/Client/ClientRegistryTest.php
+++ b/tests/Client/ClientRegistryTest.php
@@ -61,7 +61,7 @@ class ClientRegistryTest extends TestCase
             'invalid' => 'knpu.oauth2.client.invalid'
         ];
         $mockContainer = $this->getMockBuilder(ContainerInterface::class)->disableOriginalConstructor()->getMock();
-        $mockContainer->method("get")->willReturn(\stdClass::class);
+        $mockContainer->method("get")->willReturn(new \stdClass());
 
         $testClientRegistry = new ClientRegistry($mockContainer, $mockServiceMap);
 

--- a/tests/Security/Authenticator/OAuth2AuthenticatorTest.php
+++ b/tests/Security/Authenticator/OAuth2AuthenticatorTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
-use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 
 class OAuth2AuthenticatorTest extends TestCase
 {
@@ -31,11 +31,12 @@ class OAuth2AuthenticatorTest extends TestCase
     public function testFetchAccessTokenSimplyReturns()
     {
         $authenticator = new StubOauth2Authenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
             ->willReturn('expected_access_token');
 
-        $actualToken = $authenticator->doFetchAccessToken($client->reveal());
+        $actualToken = $authenticator->doFetchAccessToken($client);
         $this->assertEquals('expected_access_token', $actualToken);
     }
 
@@ -43,33 +44,36 @@ class OAuth2AuthenticatorTest extends TestCase
     {
         $this->expectException(NoAuthCodeAuthenticationException::class);
         $authenticator = new StubOauth2Authenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new MissingAuthorizationCodeException());
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new MissingAuthorizationCodeException());
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 
     public function testFetchAccessTokenThrowsIdentityProviderException()
     {
         $this->expectException(IdentityProviderAuthenticationException::class);
         $authenticator = new StubOauth2Authenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new IdentityProviderException("message", 42, "response"));
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new IdentityProviderException("message", 42, "response"));
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 
     public function testFetchAccessTokenThrowsInvalidStateException()
     {
         $this->expectException(InvalidStateAuthenticationException::class);
         $authenticator = new StubOauth2Authenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new InvalidStateException());
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new InvalidStateException());
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 }
 
@@ -85,7 +89,7 @@ if (class_exists(AbstractAuthenticator::class)) {
         {
         }
 
-        public function authenticate(Request $request): PassportInterface
+        public function authenticate(Request $request): Passport
         {
         }
 

--- a/tests/Security/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/Security/Authenticator/SocialAuthenticatorTest.php
@@ -26,16 +26,20 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class SocialAuthenticatorTest extends TestCase
 {
     public function testFetchAccessTokenSimplyReturns()
     {
         $authenticator = new StubSocialAuthenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
             ->willReturn('expected_access_token');
 
-        $actualToken = $authenticator->doFetchAccessToken($client->reveal());
+        $actualToken = $authenticator->doFetchAccessToken($client);
         $this->assertEquals('expected_access_token', $actualToken);
     }
 
@@ -43,33 +47,36 @@ class SocialAuthenticatorTest extends TestCase
     {
         $this->expectException(NoAuthCodeAuthenticationException::class);
         $authenticator = new StubSocialAuthenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new MissingAuthorizationCodeException());
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new MissingAuthorizationCodeException());
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 
     public function testFetchAccessTokenThrowsIdentityProviderException()
     {
         $this->expectException(IdentityProviderAuthenticationException::class);
         $authenticator = new StubSocialAuthenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new IdentityProviderException("message", 42, "response"));
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new IdentityProviderException("message", 42, "response"));
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 
     public function testFetchAccessTokenThrowsInvalidStateException()
     {
         $this->expectException(InvalidStateAuthenticationException::class);
         $authenticator = new StubSocialAuthenticator();
-        $client = $this->prophesize('KnpU\OAuth2ClientBundle\Client\OAuth2Client');
-        $client->getAccessToken([])
-            ->willThrow(new InvalidStateException());
+        $client = $this->createMock(OAuth2Client::class);
+        $client->method('getAccessToken')
+            ->with([])
+            ->willThrowException(new InvalidStateException());
 
-        $authenticator->doFetchAccessToken($client->reveal());
+        $authenticator->doFetchAccessToken($client);
     }
 
     public function testCheckCredentials()
@@ -99,6 +106,8 @@ class StubSocialAuthenticator extends SocialAuthenticator
     public function supports(Request $request): bool
     {
     }
+
+    /** @return mixed */
     public function getCredentials(Request $request)
     {
     }
@@ -115,7 +124,7 @@ class StubSocialAuthenticator extends SocialAuthenticator
 
 class SomeUser implements UserInterface
 {
-    public function getRoles()
+    public function getRoles(): array
     {
     }
 

--- a/tests/Security/Helper/FinishRegistrationBehaviorTest.php
+++ b/tests/Security/Helper/FinishRegistrationBehaviorTest.php
@@ -14,7 +14,6 @@ use KnpU\OAuth2ClientBundle\Security\Exception\FinishRegistrationException;
 use KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior;
 use LogicException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * @author Serghei Luchianenco (s@luchianenco.com)
@@ -32,73 +31,52 @@ class FinishRegistrationBehaviorTest extends TestCase
 
     public function testGetUserInfoFromSession()
     {
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
-        $session = $this->prophesize(Session::class);
-        $session->get('guard.finish_registration.user_information')
-            ->willReturn(['username' => 'some_user_info']);
-        $request->hasSession()->willReturn(true);
-        $request->getSession()->willReturn($session->reveal());
+        $request = $this->createRequest();
+        $request->getSession()->set('guard.finish_registration.user_information', ['username' => 'some_user_info']);
 
-        $userInfo = $this->traitObject->getUserInfoFromSession($request->reveal());
+        $userInfo = $this->traitObject->getUserInfoFromSession($request);
 
         $this->assertEquals($userInfo, ['username' => 'some_user_info']);
     }
 
     public function testGetUserInfoFromSessionWithoutSession()
     {
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
-        $request->hasSession()->willReturn(false);
-        //$request->getSession()->willReturn(null);
+        $request = $this->createRequest(false);
 
         $this->expectException(LogicException::class);
-        $this->traitObject->getUserInfoFromSession($request->reveal());
+        $this->traitObject->getUserInfoFromSession($request);
     }
 
     public function testShouldThrowExceptionIfSessionDoesNotExist()
     {
-        $mockRequest = $this->getMockRequest(false);
+        $request = $this->createRequest(false);
         $mockAuthException = new FinishRegistrationException(['id' => '1', 'name' => 'testUser']);
 
         $testFailureMessage = new FinishRegistrationBehaviorTester();
 
         $this->expectException(\LogicException::class);
-        $testFailureMessage->callSaveUserInfoToSession($mockRequest, $mockAuthException);
-    }
-
-    public function testShouldThrowExceptionIfSessionExistsButNotSessionInterface()
-    {
-        $mockRequest = $this->getMockRequest(true);
-
-        $mockAuthException = new FinishRegistrationException(['id' => '1', 'name' => 'testUser']);
-
-        $testFailureMessage = new FinishRegistrationBehaviorTester();
-
-        $this->expectException(\LogicException::class);
-        $testFailureMessage->callSaveUserInfoToSession($mockRequest, $mockAuthException);
+        $testFailureMessage->callSaveUserInfoToSession($request, $mockAuthException);
     }
 
     public function testShouldUpdateSessionDataIfSessionExists()
     {
-        $mockSession = $this->getMockBuilder(Session::class)->getMock();
-        $mockRequest = $this->getMockRequest(true, $mockSession);
+        $request = $this->createRequest();
 
         $userInfo = ['id' => '1', 'name' => 'testUser'];
         $mockAuthException = new FinishRegistrationException($userInfo);
 
         $testFailureMessage = new FinishRegistrationBehaviorTester();
 
-        $mockSession->expects($this->once())->method("set")
-            ->with(
-                $this->equalTo('guard.finish_registration.user_information'),
-                $this->equalTo($userInfo)
-            );
-        $testFailureMessage->callSaveUserInfoToSession($mockRequest, $mockAuthException);
+        $session = $request->getSession();
+        $testFailureMessage->callSaveUserInfoToSession($request, $mockAuthException);
+        $this->assertSame($userInfo, $session->get('guard.finish_registration.user_information'));
     }
 }
 
 class FinishRegistrationBehaviorTester
 {
     use FinishRegistrationBehavior;
+
     public function callSaveUserInfoToSession($request, $exception): void
     {
         $this->saveUserInfoToSession($request, $exception);

--- a/tests/Security/Helper/HelperTestMockBuilderTrait.php
+++ b/tests/Security/Helper/HelperTestMockBuilderTrait.php
@@ -11,14 +11,18 @@
 namespace KnpU\OAuth2ClientBundle\Tests\Security\Helper;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 trait HelperTestMockBuilderTrait
 {
-    private function getMockRequest($hasSessionReturn, $getSessionReturn = \stdClass::class)
+    private function createRequest(bool $withSession = true): Request
     {
-        $mockRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $mockRequest->method("hasSession")->willReturn($hasSessionReturn);
-        $mockRequest->method("getSession")->willReturn($getSessionReturn);
-        return $mockRequest;
+        $request = Request::create('/');
+        if ($withSession) {
+            $request->setSession(new Session(new MockArraySessionStorage()));
+        }
+
+        return $request;
     }
 }

--- a/tests/Security/Helper/PreviousUrlHelperTest.php
+++ b/tests/Security/Helper/PreviousUrlHelperTest.php
@@ -8,10 +8,8 @@
  * file that was distributed with this source code.
  */
 
-namespace KnpU\OAuth2ClientBundle\tests\Security\Helper;
+namespace KnpU\OAuth2ClientBundle\Tests\Security\Helper;
 
-use LogicException;
-use Symfony\Component\HttpFoundation\Session\Session;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PreviousUrlHelperTest extends TestCase
 {
+    use HelperTestMockBuilderTrait;
     private $traitObject;
 
     public function setUp(): void
@@ -29,15 +28,12 @@ class PreviousUrlHelperTest extends TestCase
 
     public function testGetPreviousUrl()
     {
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
-        $session = $this->prophesize(Session::class);
-        $session->get('_security.some_firewall_name.target_path')
-            ->willReturn('/some/url');
+        $request = $this->createRequest();
+        $session = $request->getSession();
+        $session->set('_security.some_firewall_name.target_path', '/some/url');
 
-        $request->hasSession()->willReturn(true);
-        $request->getSession()->willReturn($session->reveal());
         $previousUrl = $this->traitObject->getPreviousUrl(
-            $request->reveal(),
+            $request,
             'some_firewall_name'
         );
 
@@ -46,11 +42,10 @@ class PreviousUrlHelperTest extends TestCase
 
     public function testGetPreviousUrlWithoutSession()
     {
-        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
-        $request->hasSession()->willReturn(false);
+        $request = $this->createRequest(false);
 
         $previousUrl = $this->traitObject->getPreviousUrl(
-            $request->reveal(),
+            $request,
             'some_firewall_name'
         );
 

--- a/tests/Security/Helper/SaveAuthFailureMessageTest.php
+++ b/tests/Security/Helper/SaveAuthFailureMessageTest.php
@@ -22,47 +22,33 @@ class SaveAuthFailureMessageTest extends TestCase
 
     public function testShouldThrowExceptionIfSessionDoesNotExist()
     {
-        $mockRequest = $this->getMockRequest(false);
+        $request = $this->createRequest(false);
         $mockAuthException = new AuthenticationException();
 
         $testFailureMessage = new SaveAuthFailureMessageTester();
 
         $this->expectException(\LogicException::class);
-        $testFailureMessage->callSaveAuthenticationErrorToSession($mockRequest, $mockAuthException);
-    }
-
-    public function testShouldThrowExceptionIfExistsButIsNotSessionInterface()
-    {
-        $mockRequest = $this->getMockRequest(true);
-        $mockAuthException = new AuthenticationException();
-
-        $testFailureMessage = new SaveAuthFailureMessageTester();
-
-        $this->expectException(\LogicException::class);
-        $testFailureMessage->callSaveAuthenticationErrorToSession($mockRequest, $mockAuthException);
+        $testFailureMessage->callSaveAuthenticationErrorToSession($request, $mockAuthException);
     }
 
     public function testShouldUpdateSessionErrorIfSessionExists()
     {
-        $mockSession = $this->getMockBuilder(SessionInterface::class)->getMock();
-        $mockRequest = $this->getMockRequest(true, $mockSession);
+        $request = $this->createRequest();
 
         $mockAuthException = new AuthenticationException();
 
         $testFailureMessage = new SaveAuthFailureMessageTester();
 
-        $mockSession->expects($this->once())->method("set")
-            ->with(
-                $this->equalTo(Security::AUTHENTICATION_ERROR),
-                $this->isInstanceOf(AuthenticationException::class)
-            );
-        $testFailureMessage->callSaveAuthenticationErrorToSession($mockRequest, $mockAuthException);
+        $testFailureMessage->callSaveAuthenticationErrorToSession($request, $mockAuthException);
+        $session = $request->getSession();
+        $this->assertInstanceOf(AuthenticationException::class, $session->get(Security::AUTHENTICATION_ERROR));
     }
 }
 
 class SaveAuthFailureMessageTester
 {
     use SaveAuthFailureMessage;
+
     public function callSaveAuthenticationErrorToSession($request, $exception): void
     {
         $this->saveAuthenticationErrorToSession($request, $exception);

--- a/tests/allowed.json
+++ b/tests/allowed.json
@@ -1,0 +1,7 @@
+[
+    {
+        "location": "KnpU\\OAuth2ClientBundle\\Tests\\Client\\ClientRegistryTest::testShouldKnowWhatServicesAreConfigured",
+        "message": "The \"KnpU\\OAuth2ClientBundle\\Security\\Authenticator\\SocialAuthenticator\" class extends \"Symfony\\Component\\Security\\Guard\\AbstractGuardAuthenticator\" that is deprecated since Symfony 5.3, use the new authenticator system instead.",
+        "count": 1
+    }
+]


### PR DESCRIPTION
~TODO: remove (at least) php-cs-fixer so that Symfony 6 is used in tests.~