### PR TITLE
Bring back bin/update-readme status check to CI again

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -55,5 +55,14 @@ jobs:
         name: bin/update_readme
         runs-on: ubuntu-latest
         steps:
-          - name: Check Status
-            run: ./bin/update_readme && git diff --exit-code README.md
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+
+            - name: Install dependencies
+              run: composer install
+
+            - name: Check Status
+              run: ./bin/update_readme && git diff --exit-code README.md

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -49,3 +49,11 @@ jobs:
 
             - name: Run script
               run: vendor/bin/phpstan analyse
+
+    # Fail CI if repo is in dirty state after bin/update_readme
+    update-readme:
+        name: bin/update_readme
+        runs-on: ubuntu-latest
+        steps:
+          - name: Check Status
+            run: ./bin/update_readme && git diff --exit-code README.md

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ via Composer:
 <a name="client-downloader-table"></a>
 
 | OAuth2 Provider                                                        | Install                                             |
-| ---------------------------------------------------------------------- | --------------------------------------------------- |
+| ---------------------------------------------------------------------- | ------------------------------------------------------- |
 | [Amazon](https://github.com/luchianenco/oauth2-amazon)                 | composer require luchianenco/oauth2-amazon          |
 | [AppID](https://github.com/Jampire/oauth2-appid)                       | composer require jampire/oauth2-appid               |
 | [Apple](https://github.com/patrickbussmann/oauth2-apple)               | composer require patrickbussmann/oauth2-apple       |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ via Composer:
 <a name="client-downloader-table"></a>
 
 | OAuth2 Provider                                                        | Install                                             |
-| ---------------------------------------------------------------------- | ------------------------------------------------------- |
+| ---------------------------------------------------------------------- | --------------------------------------------------- |
 | [Amazon](https://github.com/luchianenco/oauth2-amazon)                 | composer require luchianenco/oauth2-amazon          |
 | [AppID](https://github.com/Jampire/oauth2-appid)                       | composer require jampire/oauth2-appid               |
 | [Apple](https://github.com/patrickbussmann/oauth2-apple)               | composer require patrickbussmann/oauth2-apple       |


### PR DESCRIPTION
This feature was lost in #289 after migration from Travis to GitHub Actions