### PR TITLE
[docs]: Add entrypoint functionality to Authenticator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
-class MyFacebookAuthenticator extends OAuth2Authenticator
+class MyFacebookAuthenticator extends OAuth2Authenticator implements AuthenticationEntrypointInterface
 {
     private $clientRegistry;
     private $entityManager;
@@ -350,6 +351,18 @@ class MyFacebookAuthenticator extends OAuth2Authenticator
         $message = strtr($exception->getMessageKey(), $exception->getMessageData());
 
         return new Response($message, Response::HTTP_FORBIDDEN);
+    }
+    
+   /**
+     * Called when authentication is needed, but it's not sent.
+     * This redirects to the 'login'.
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new RedirectResponse(
+            '/connect/', // might be the site, where users choose their oauth provider
+            Response::HTTP_TEMPORARY_REDIRECT
+        );
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ class MyFacebookAuthenticator extends OAuth2Authenticator implements Authenticat
      * Called when authentication is needed, but it's not sent.
      * This redirects to the 'login'.
      */
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null): Response
     {
         return new RedirectResponse(
             '/connect/', // might be the site, where users choose their oauth provider

--- a/src/DependencyInjection/Providers/GeocachingProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GeocachingProviderConfigurator.php
@@ -24,7 +24,7 @@ class GeocachingProviderConfigurator implements ProviderConfiguratorInterface
             ->info('dev, staging or production')
             ->example('environment: production')
         ->end()
-    ;
+        ;
     }
 
     public function getProviderClass(array $config)


### PR DESCRIPTION
As best I can tell, the `start()` method is still required to automatically redirect to the "login" page when accessing a protected resource. This PR copies its use from the Guard Authenticator to the Symfony Authenticator section.