### PR TITLE
Add certificate support for Azure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,11 @@ knpu_oauth2_client:
             type: azure
             # add and set these environment variables in your .env files
             client_id: '%env(OAUTH_AZURE_CLIENT_ID)%'
+            # client_secret is optional if you use a client certificate
             client_secret: '%env(OAUTH_AZURE_CLIENT_SECRET)%'
+            # Using a client certificate requires thenetworg/oauth2-azure > 2.1.1:
+            # client_certificate_private_key: '%env(OAUTH_AZURE_CLIENT_CERTIFICATE_PRIVATE_KEY)%'
+            # client_certificate_thumbprint: '%env(OAUTH_AZURE_CLIENT_CERTIFICATE_THUMBPRINT)%'
             # a route name you'll create
             redirect_route: connect_azure_check
             redirect_params: {}

--- a/README.md
+++ b/README.md
@@ -694,14 +694,15 @@ knpu_oauth2_client:
             type: azure
             # add and set these environment variables in your .env files
             client_id: '%env(OAUTH_AZURE_CLIENT_ID)%'
-            # client_secret is optional if you use a client certificate
-            client_secret: '%env(OAUTH_AZURE_CLIENT_SECRET)%'
-            # Using a client certificate requires thenetworg/oauth2-azure > 2.1.1:
-            # client_certificate_private_key: '%env(OAUTH_AZURE_CLIENT_CERTIFICATE_PRIVATE_KEY)%'
-            # client_certificate_thumbprint: '%env(OAUTH_AZURE_CLIENT_CERTIFICATE_THUMBPRINT)%'
             # a route name you'll create
             redirect_route: connect_azure_check
             redirect_params: {}
+            # The shared client secret if you don't use a certificate
+            # client_secret: ''
+            # The contents of the client certificate private key
+            # client_certificate_private_key: '-----BEGIN RSA PRIVATE KEY-----\nMIIEog...G82ARGuI=\n-----END RSA PRIVATE KEY-----'
+            # The hexadecimal thumbprint of the client certificate
+            # client_certificate_thumbprint: 'B4A94A83092455AC4D3AC827F02B61646EAAC43D'
             # Domain to build login URL
             # url_login: 'https://login.microsoftonline.com/'
             # Oauth path to authorize against

--- a/src/DependencyInjection/Providers/AzureProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AzureProviderConfigurator.php
@@ -14,27 +14,26 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class AzureProviderConfigurator implements ProviderConfiguratorInterface, ProviderWithoutClientSecretConfiguratorInterface
 {
-
     public function needsClientSecret(): bool
     {
-      //We define the `client_secret`-node ourselves to make it optional with certificate
-      return false;
+        // We define the `client_secret`-node ourselves to make it optional with certificate
+        return false;
     }
 
     public function buildConfiguration(NodeBuilder $node)
     {
         $node
             ->scalarNode('client_secret')
-              ->info('The shared client secret')
+              ->info('The shared client secret if you don\'t use a certificate')
               ->defaultValue('')
             ->end()
             ->scalarNode('client_certificate_private_key')
-              ->example('-----BEGIN RSA PRIVATE KEY-----\nMIIEog...G82ARGuI=\n-----END RSA PRIVATE KEY-----')
+              ->example("client_certificate_private_key: '-----BEGIN RSA PRIVATE KEY-----\\nMIIEog...G82ARGuI=\\n-----END RSA PRIVATE KEY-----'")
               ->info('The contents of the client certificate private key')
               ->defaultValue('')
             ->end()
             ->scalarNode('client_certificate_thumbprint')
-              ->example('B4A94A83092455AC4D3AC827F02B61646EAAC43D')
+              ->example("client_certificate_thumbprint: 'B4A94A83092455AC4D3AC827F02B61646EAAC43D'")
               ->info('The hexadecimal thumbprint of the client certificate')
               ->defaultValue('')
             ->end()
@@ -87,21 +86,21 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface, Provid
                 ->defaultValue('1.0')
             ->end();
 
-      //Validate that either client_secret or client_certificate_private_key is set:
-      $node
-          ->end()
-            ->validate()
-              ->ifTrue(function($v) {
-                  return empty($v['client_secret']) && empty($v['client_certificate_private_key']);
-              })
-              ->thenInvalid('You have to define either client_secret or client_certificate_private_key')
+        // Validate that either client_secret or client_certificate_private_key is set:
+        $node
             ->end()
               ->validate()
-              ->ifTrue(function($v) {
-                  return !empty($v['client_certificate_private_key']) && empty($v['client_certificate_thumbprint']);
-              })
-            ->thenInvalid('You have to define the client_certificate_thumbprint when using a certificate')
-          ->end();
+                ->ifTrue(function ($v) {
+                    return empty($v['client_secret']) && empty($v['client_certificate_private_key']);
+                })
+                ->thenInvalid('You have to define either client_secret or client_certificate_private_key')
+              ->end()
+                ->validate()
+                ->ifTrue(function ($v) {
+                    return !empty($v['client_certificate_private_key']) && empty($v['client_certificate_thumbprint']);
+                })
+              ->thenInvalid('You have to define the client_certificate_thumbprint when using a certificate')
+            ->end();
     }
 
     public function getProviderClass(array $config)


### PR DESCRIPTION
Adds certificate support to the **Azure provider**:

- Makes configuration option `client_secret` optional
- Adds configuration options `client_certificate_private_key` and `client_certificate_thumbprint`

See https://github.com/TheNetworg/oauth2-azure/pull/170 (merged) for the respective PR on the provider.

That PR is not released, yet, but there are no compatibility issues with this PR here. They can be installed independently without drawbacks.

Only to actually use certificates you had to have both PRs merged/released/installed.