### PR TITLE
Allow null as redirect_route

### DIFF
--- a/src/DependencyInjection/ProviderFactory.php
+++ b/src/DependencyInjection/ProviderFactory.php
@@ -38,12 +38,14 @@ class ProviderFactory
      *
      * @return mixed
      */
-    public function createProvider($class, array $options, $redirectUri, array $redirectParams = [], array $collaborators = [])
+    public function createProvider($class, array $options, string $redirectUri = null, array $redirectParams = [], array $collaborators = [])
     {
-        $redirectUri = $this->generator
-            ->generate($redirectUri, $redirectParams, UrlGeneratorInterface::ABSOLUTE_URL);
+        if ($redirectUri !== null) {
+            $redirectUri = $this->generator
+                ->generate($redirectUri, $redirectParams, UrlGeneratorInterface::ABSOLUTE_URL);
 
-        $options['redirectUri'] = $redirectUri;
+            $options['redirectUri'] = $redirectUri;
+        }
 
         return new $class($options, $collaborators);
     }

--- a/tests/DependencyInjection/ProviderFactoryTest.php
+++ b/tests/DependencyInjection/ProviderFactoryTest.php
@@ -32,6 +32,19 @@ class ProviderFactoryTest extends TestCase
         $this->assertEquals([], $result->getCollaborators());
     }
 
+    public function testShouldCreateProviderWithNullRedirectUrl()
+    {
+        $mockGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();
+        $mockGenerator->expects($this->never())->method("generate");
+
+        $testProviderFactory = new ProviderFactory($mockGenerator);
+        $result = $testProviderFactory->createProvider(MockProvider::class, [], null);
+
+        $this->assertInstanceOf(MockProvider::class, $result);
+        $this->assertEquals([], $result->getOptions());
+        $this->assertEquals([], $result->getCollaborators());
+    }
+
     private function getMockGenerator($generateReturn)
     {
         $mockGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
The functionality “Fetching access keys via OAuth2 to be used with an API” mentioned in the README does not necessarily need a `redirect_url`, thus providing it should not be mandatory. We have an Endpoint (pingen.com) which does not allow `redirect_url` to be sent in these cases. Also, it wouldn't make much sense if it did because the route must be a valid symfony route, which in some cases must be created without a use.
I also think it makes sense to allow `null` here because this parameter isn't mandatory in the `League\OAuth2\Client\ProviderAbstractProvider` (https://github.com/thephpleague/oauth2-client/blob/master/src/Provider/AbstractProvider.php#L454). 