### PR TITLE
Drop legacy PHP support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         # normal, highest, non-dev installs
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         composer-options: ['--prefer-stable']
         dependency-versions: ['highest']
         include:
           # testing lowest php with lowest dependencies
-          - php-version: '7.2'
+          - php-version: '7.4'
             dependency-versions: 'lowest'
             composer-options: '--prefer-lowest'
           # testing dev versions with highest PHP

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.4",
         "symfony/framework-bundle": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/routing": "^4.4|^5.0|^6.0",

--- a/src/Client/ClientRegistry.php
+++ b/src/Client/ClientRegistry.php
@@ -14,11 +14,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ClientRegistry
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var array */
-    private $serviceMap;
+    private array $serviceMap;
 
     /**
      * ClientRegistry constructor.

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -23,14 +23,11 @@ class OAuth2Client implements OAuth2ClientInterface
 {
     public const OAUTH2_SESSION_STATE_KEY = 'knpu.oauth2_client_state';
 
-    /** @var AbstractProvider */
-    private $provider;
+    private AbstractProvider $provider;
 
-    /** @var RequestStack */
-    private $requestStack;
+    private RequestStack $requestStack;
 
-    /** @var bool */
-    private $isStateless = false;
+    private bool $isStateless = false;
 
     /**
      * OAuth2Client constructor.

--- a/src/Client/OAuth2PKCEClient.php
+++ b/src/Client/OAuth2PKCEClient.php
@@ -27,8 +27,7 @@ class OAuth2PKCEClient extends OAuth2Client
 {
     public const VERIFIER_KEY = 'pkce_code_verifier';
 
-    /** @var RequestStack */
-    private $requestStack;
+    private RequestStack $requestStack;
 
     public function __construct(AbstractProvider $provider,
                                 RequestStack $requestStack)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,9 +46,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
             ->validate()
-                ->ifTrue(function ($v) {
-                    return isset($v['http_client_options'], $v['http_client']) && !empty($v['http_client_options']);
-                })
+                ->ifTrue(fn ($v) => isset($v['http_client_options'], $v['http_client']) && !empty($v['http_client_options']))
                 ->thenInvalid('You cannot use both "http_client_options" and "http_client" at the same time under "knpu_oauth2_client".')
             ->end()
         ;

--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -86,14 +86,11 @@ class KnpUOAuth2ClientExtension extends Extension
     /** @var bool */
     private $checkExternalClassExistence;
 
-    /** @var array */
-    private $configurators = [];
+    private array $configurators = [];
 
-    /** @var array */
-    private $duplicateProviderTypes = [];
+    private array $duplicateProviderTypes = [];
 
-    /** @var array */
-    private static $supportedProviderTypes = [
+    private static array $supportedProviderTypes = [
         'amazon' => AmazonProviderConfigurator::class,
         'appid' => AppIdProviderConfigurator::class,
         'apple' => AppleProviderConfigurator::class,

--- a/src/DependencyInjection/ProviderFactory.php
+++ b/src/DependencyInjection/ProviderFactory.php
@@ -19,8 +19,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class ProviderFactory
 {
-    /** @var UrlGeneratorInterface */
-    private $generator;
+    private UrlGeneratorInterface $generator;
 
     /**
      * ProviderFactory constructor.

--- a/src/DependencyInjection/Providers/AmazonProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AmazonProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\AmazonClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class AmazonProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class AmazonProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\AmazonClient';
+        return AmazonClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/AppIdProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AppIdProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\AppIdClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**
@@ -47,7 +48,7 @@ class AppIdProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\AppIdClient';
+        return AppIdClient::class;
     }
 
     public function getProviderOptions(array $configuration)

--- a/src/DependencyInjection/Providers/AppleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AppleProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\AppleClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class AppleProviderConfigurator implements ProviderConfiguratorInterface, ProviderWithoutClientSecretConfiguratorInterface
@@ -41,7 +42,7 @@ class AppleProviderConfigurator implements ProviderConfiguratorInterface, Provid
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\AppleClient';
+        return AppleClient::class;
     }
 
     public function getProviderOptions(array $configuration)

--- a/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/Auth0ProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\Auth0Client;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
@@ -65,6 +66,6 @@ class Auth0ProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\Auth0Client';
+        return Auth0Client::class;
     }
 }

--- a/src/DependencyInjection/Providers/AzureProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/AzureProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\AzureClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class AzureProviderConfigurator implements ProviderConfiguratorInterface, ProviderWithoutClientSecretConfiguratorInterface
@@ -90,15 +91,11 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface, Provid
         $node
             ->end()
               ->validate()
-                ->ifTrue(function ($v) {
-                    return empty($v['client_secret']) && empty($v['client_certificate_private_key']);
-                })
+                ->ifTrue(fn ($v) => empty($v['client_secret']) && empty($v['client_certificate_private_key']))
                 ->thenInvalid('You have to define either client_secret or client_certificate_private_key')
               ->end()
                 ->validate()
-                ->ifTrue(function ($v) {
-                    return !empty($v['client_certificate_private_key']) && empty($v['client_certificate_thumbprint']);
-                })
+                ->ifTrue(fn ($v) => !empty($v['client_certificate_private_key']) && empty($v['client_certificate_thumbprint']))
               ->thenInvalid('You have to define the client_certificate_thumbprint when using a certificate')
             ->end();
     }
@@ -145,6 +142,6 @@ class AzureProviderConfigurator implements ProviderConfiguratorInterface, Provid
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\AzureClient';
+        return AzureClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/BitbucketProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/BitbucketProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\BitbucketClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class BitbucketProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class BitbucketProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\BitbucketClient';
+        return BitbucketClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/BoxProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/BoxProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\BoxClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class BoxProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class BoxProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\BoxClient';
+        return BoxClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/BuddyProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/BuddyProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\BuddyClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class BuddyProviderConfigurator implements ProviderConfiguratorInterface
@@ -55,6 +56,6 @@ class BuddyProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\BuddyClient';
+        return BuddyClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/BufferProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/BufferProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\BufferClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class BufferProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class BufferProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\BufferClient';
+        return BufferClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/CanvasLMSProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/CanvasLMSProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\CanvasLMSClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class CanvasLMSProviderConfigurator implements ProviderConfiguratorInterface
@@ -64,6 +65,6 @@ class CanvasLMSProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\CanvasLMSClient';
+        return CanvasLMSClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/CleverProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/CleverProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\CleverClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class CleverProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class CleverProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\CleverClient';
+        return CleverClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DevianArtProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DevianArtProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DevianArtClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DevianArtProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class DevianArtProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DevianArtClient';
+        return DevianArtClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DigitalOceanProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DigitalOceanProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DigitalOceanClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DigitalOceanProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class DigitalOceanProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DigitalOceanClient';
+        return DigitalOceanClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DiscordProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DiscordProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DiscordClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DiscordProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class DiscordProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DiscordClient';
+        return DiscordClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DribbbleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DribbbleProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DribbbleClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DribbbleProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class DribbbleProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DribbbleClient';
+        return DribbbleClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DropboxProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DropboxProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DropboxClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DropboxProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class DropboxProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DropboxClient';
+        return DropboxClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/DrupalProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/DrupalProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\DrupalClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class DrupalProviderConfigurator implements ProviderConfiguratorInterface
@@ -56,6 +57,6 @@ class DrupalProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\DrupalClient';
+        return DrupalClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/ElanceProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/ElanceProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\ElanceClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class ElanceProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class ElanceProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\ElanceClient';
+        return ElanceClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/EveOnlineProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/EveOnlineProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\EveOnlineClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class EveOnlineProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class EveOnlineProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\EveOnlineClient';
+        return EveOnlineClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/EventbriteProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/EventbriteProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\EventbriteClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class EventbriteProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class EventbriteProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\EventbriteClient';
+        return EventbriteClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/FacebookProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/FacebookProviderConfigurator.php
@@ -10,6 +10,8 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient;
+use League\OAuth2\Client\Provider\Facebook;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class FacebookProviderConfigurator implements ProviderConfiguratorInterface
@@ -26,7 +28,7 @@ class FacebookProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getProviderClass(array $config)
     {
-        return 'League\OAuth2\Client\Provider\Facebook';
+        return Facebook::class;
     }
 
     public function getProviderOptions(array $config)
@@ -55,6 +57,6 @@ class FacebookProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient';
+        return FacebookClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/FitbitProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/FitbitProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\FitbitClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class FitbitProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class FitbitProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\FitbitClient';
+        return FitbitClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/FoursquareProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/FoursquareProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\FoursquareClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class FoursquareProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class FoursquareProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\FoursquareClient';
+        return FoursquareClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/GenericProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GenericProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class GenericProviderConfigurator implements ProviderConfiguratorInterface
@@ -23,7 +24,7 @@ class GenericProviderConfigurator implements ProviderConfiguratorInterface
             ->end()
             ->scalarNode('client_class')
                 ->info('If you have a sub-class of OAuth2Client you want to use, add it here')
-                ->defaultValue('KnpU\OAuth2ClientBundle\Client\OAuth2Client')
+                ->defaultValue(OAuth2Client::class)
             ->end()
             ->arrayNode('provider_options')
                 ->info('Other options to pass to your provider\'s constructor')

--- a/src/DependencyInjection/Providers/GithubProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GithubProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\GithubClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class GithubProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class GithubProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\GithubClient';
+        return GithubClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/GitlabProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GitlabProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\GitlabClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**
@@ -60,6 +61,6 @@ class GitlabProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\GitlabClient';
+        return GitlabClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/GoogleProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/GoogleProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\GoogleClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class GoogleProviderConfigurator implements ProviderConfiguratorInterface
@@ -83,6 +84,6 @@ class GoogleProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\GoogleClient';
+        return GoogleClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/HeadHunterProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/HeadHunterProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\HeadHunterClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class HeadHunterProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class HeadHunterProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\HeadHunterClient';
+        return HeadHunterClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/HerokuProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/HerokuProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\HerokuClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class HerokuProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class HerokuProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\HerokuClient';
+        return HerokuClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/KeycloakProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/KeycloakProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\KeycloakClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class KeycloakProviderConfigurator implements ProviderConfiguratorInterface
@@ -79,6 +80,6 @@ class KeycloakProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\KeycloakClient';
+        return KeycloakClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/LinkedInProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\LinkedInClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
@@ -68,6 +69,6 @@ class LinkedInProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\LinkedInClient';
+        return LinkedInClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/MailRuProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/MailRuProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\MailRuClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class MailRuProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class MailRuProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\MailRuClient';
+        return MailRuClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/MicrosoftProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/MicrosoftProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\MicrosoftClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class MicrosoftProviderConfigurator implements ProviderConfiguratorInterface
@@ -76,6 +77,6 @@ class MicrosoftProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\MicrosoftClient';
+        return MicrosoftClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/MollieProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/MollieProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\MollieClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class MollieProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class MollieProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\MollieClient';
+        return MollieClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/OdnoklassnikiProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/OdnoklassnikiProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\OdnoklassnikiClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class OdnoklassnikiProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class OdnoklassnikiProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\OdnoklassnikiClient';
+        return OdnoklassnikiClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/OktaProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/OktaProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\OktaClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class OktaProviderConfigurator implements ProviderConfiguratorInterface
@@ -60,6 +61,6 @@ class OktaProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\OktaClient';
+        return OktaClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/PaypalProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/PaypalProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\PaypalClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class PaypalProviderConfigurator implements ProviderConfiguratorInterface
@@ -55,6 +56,6 @@ class PaypalProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\PaypalClient';
+        return PaypalClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/PsnProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/PsnProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\PsnClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class PsnProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class PsnProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\PsnClient';
+        return PsnClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/SalesforceProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/SalesforceProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\SalesforceClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class SalesforceProviderConfigurator implements ProviderConfiguratorInterface
@@ -55,6 +56,6 @@ class SalesforceProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\SalesforceClient';
+        return SalesforceClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/SlackProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/SlackProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\SlackClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class SlackProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class SlackProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\SlackClient';
+        return SlackClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/StravaProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/StravaProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\StravaClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class StravaProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class StravaProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\StravaClient';
+        return StravaClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/StripeProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/StripeProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\StripeClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class StripeProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class StripeProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\StripeClient';
+        return StripeClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/SymfonyConnectProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/SymfonyConnectProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\SymfonyConnectClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class SymfonyConnectProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class SymfonyConnectProviderConfigurator implements ProviderConfiguratorInterfac
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\SymfonyConnectClient';
+        return SymfonyConnectClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/TwitchProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/TwitchProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\TwitchClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class TwitchProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class TwitchProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\TwitchClient';
+        return TwitchClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/UberProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/UberProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\UberClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class UberProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class UberProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\UberClient';
+        return UberClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/UnsplashProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/UnsplashProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\UnsplashClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class UnsplashProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class UnsplashProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\UnsplashClient';
+        return UnsplashClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/VKontakteProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/VKontakteProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\VKontakteClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class VKontakteProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class VKontakteProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\VKontakteClient';
+        return VKontakteClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/VimeoProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/VimeoProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\VimeoClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class VimeoProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class VimeoProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\VimeoClient';
+        return VimeoClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/WaveProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/WaveProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\WaveClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class WaveProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class WaveProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\WaveClient';
+        return WaveClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/YahooProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/YahooProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\YahooClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class YahooProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class YahooProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\YahooClient';
+        return YahooClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/YandexProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/YandexProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\YandexClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class YandexProviderConfigurator implements ProviderConfiguratorInterface
@@ -49,6 +50,6 @@ class YandexProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\YandexClient';
+        return YandexClient::class;
     }
 }

--- a/src/DependencyInjection/Providers/ZendeskProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/ZendeskProviderConfigurator.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\DependencyInjection\Providers;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\ZendeskClient;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 class ZendeskProviderConfigurator implements ProviderConfiguratorInterface
@@ -55,6 +56,6 @@ class ZendeskProviderConfigurator implements ProviderConfiguratorInterface
 
     public function getClientClass(array $config)
     {
-        return 'KnpU\OAuth2ClientBundle\Client\Provider\ZendeskClient';
+        return ZendeskClient::class;
     }
 }

--- a/src/Security/User/OAuthUser.php
+++ b/src/Security/User/OAuthUser.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class OAuthUser implements UserInterface
 {
     private $username;
-    private $roles;
+    private array $roles;
 
     public function __construct($username, array $roles)
     {

--- a/src/Security/User/OAuthUserProvider.php
+++ b/src/Security/User/OAuthUserProvider.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class OAuthUserProvider implements UserProviderInterface
 {
-    private $roles;
+    private array $roles;
 
     public function __construct(array $roles = ['ROLE_USER', 'ROLE_OAUTH_USER'])
     {

--- a/tests/Client/OAuth2ClientTest.php
+++ b/tests/Client/OAuth2ClientTest.php
@@ -26,10 +26,9 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class OAuth2ClientTest extends TestCase
 {
-    private $requestStack;
-    /** @var Request */
-    private $request;
-    private $session;
+    private RequestStack $requestStack;
+    private Request $request;
+    private Session $session;
     private $provider;
 
     public function setup(): void
@@ -59,7 +58,7 @@ class OAuth2ClientTest extends TestCase
 
         $response = $client->redirect(['scope1', 'scope2']);
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\RedirectResponse',
+            RedirectResponse::class,
             $response
         );
         $this->assertEquals(
@@ -273,7 +272,7 @@ class OAuth2ClientTest extends TestCase
         $this->provider->method('getResourceOwner')
             ->with($actualToken)
             ->willReturn($resourceOwner);
-        $user = $client->fetchUser($actualToken);
+        $user = $client->fetchUser();
 
         $this->assertInstanceOf(FacebookUser::class, $user);
         $this->assertEquals('testUser', $user->getName());

--- a/tests/Client/OAuth2PKCEClientTest.php
+++ b/tests/Client/OAuth2PKCEClientTest.php
@@ -16,6 +16,7 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -23,10 +24,10 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class OAuth2PKCEClientTest extends TestCase
 {
-    private $requestStack;
-    private $request;
-    private $session;
-    private $provider;
+    private RequestStack $requestStack;
+    private Request $request;
+    private Session $session;
+    private AbstractProvider $provider;
 
     public function setup(): void
     {
@@ -86,7 +87,7 @@ class OAuth2PKCEClientTest extends TestCase
 
         $response = $client->redirect();
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\RedirectResponse',
+            RedirectResponse::class,
             $response
         );
 

--- a/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
+++ b/tests/DependencyInjection/KnpUOAuth2ClientExtensionTest.php
@@ -10,8 +10,10 @@
 
 namespace KnpU\OAuth2ClientBundle\tests\DependencyInjection;
 
+use KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient;
 use KnpU\OAuth2ClientBundle\DependencyInjection\KnpUOAuth2ClientExtension;
 use KnpU\OAuth2ClientBundle\DependencyInjection\Providers\ProviderConfiguratorInterface;
+use League\OAuth2\Client\Provider\Facebook;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BooleanNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -62,7 +64,7 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
 
         $this->assertEquals(
             [
-                'League\OAuth2\Client\Provider\Facebook',
+                Facebook::class,
                 ['clientId' => 'CLIENT_ID', 'clientSecret' => 'SECRET', 'graphApiVersion' => 'API_VERSION'],
                 'the_route_name',
                 ['route_params' => 'foo'],
@@ -75,7 +77,7 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
         // the custom class is used
         $clientDefinition = $this->configuration->getDefinition('knpu.oauth2.client.facebook');
         $this->assertEquals(
-            'KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient',
+            FacebookClient::class,
             $clientDefinition->getClass()
         );
         $this->assertEquals(
@@ -88,7 +90,7 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
 
         // the client service has an alias
         $this->assertTrue(
-            $this->configuration->hasAlias('KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient'),
+            $this->configuration->hasAlias(FacebookClient::class),
             'FacebookClient service is missing an alias'
         );
     }
@@ -150,7 +152,7 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
                 'client_secret' => 'CLIENT_SECRET_TEST',
                 'redirect_route' => 'go_there',
                 'redirect_params' => [],
-                'use_state' => rand(0, 1) == 0,
+                'use_state' => random_int(0, 1) === 0,
             ];
 
             if (!KnpUOAuth2ClientExtension::configuratorNeedsClientSecret($configurator)) {
@@ -163,11 +165,11 @@ class KnpUOAuth2ClientExtensionTest extends TestCase
                 if ($child instanceof ArrayNode) {
                     $config[$child->getName()] = [];
                 } elseif ($child instanceof BooleanNode) {
-                    $config[$child->getName()] = (bool) rand(0, 1);
+                    $config[$child->getName()] = (bool) random_int(0, 1);
                 } elseif ($child instanceof IntegerNode) {
-                    $config[$child->getName()] = rand();
+                    $config[$child->getName()] = random_int(0, mt_getrandmax());
                 } else {
-                    $config[$child->getName()] = 'random_'.rand();
+                    $config[$child->getName()] = 'random_'.random_int(0, mt_getrandmax());
                 }
             }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -11,7 +11,9 @@
 namespace KnpU\OAuth2ClientBundle\tests;
 
 use GuzzleHttp\Client;
+use KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient;
 use KnpU\OAuth2ClientBundle\Tests\app\TestKernel;
+use League\OAuth2\Client\Provider\Facebook;
 use PHPUnit\Framework\TestCase;
 
 class FunctionalTest extends TestCase
@@ -25,8 +27,8 @@ class FunctionalTest extends TestCase
 
         /** @var \KnpU\OAuth2ClientBundle\Client\OAuth2Client $client */
         $client = $container->get('knpu.oauth2.client.my_facebook');
-        $this->assertInstanceOf('KnpU\OAuth2ClientBundle\Client\Provider\FacebookClient', $client);
-        $this->assertInstanceOf('League\OAuth2\Client\Provider\Facebook', $client->getOAuth2Provider());
+        $this->assertInstanceOf(FacebookClient::class, $client);
+        $this->assertInstanceOf(Facebook::class, $client->getOAuth2Provider());
 
         $client2 = $container->get('knpu.oauth2.registry')
             ->getClient('my_facebook');

--- a/tests/Security/Helper/FinishRegistrationBehaviorTest.php
+++ b/tests/Security/Helper/FinishRegistrationBehaviorTest.php
@@ -26,7 +26,7 @@ class FinishRegistrationBehaviorTest extends TestCase
     public function setUp(): void
     {
         $this->traitObject = $this
-            ->getMockForTrait('KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior');
+            ->getMockForTrait(FinishRegistrationBehavior::class);
     }
 
     public function testGetUserInfoFromSession()

--- a/tests/Security/Helper/PreviousUrlHelperTest.php
+++ b/tests/Security/Helper/PreviousUrlHelperTest.php
@@ -10,6 +10,7 @@
 
 namespace KnpU\OAuth2ClientBundle\Tests\Security\Helper;
 
+use KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,7 +24,7 @@ class PreviousUrlHelperTest extends TestCase
     public function setUp(): void
     {
         $this->traitObject = $this
-            ->getMockForTrait('KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper');
+            ->getMockForTrait(PreviousUrlHelper::class);
     }
 
     public function testGetPreviousUrl()


### PR DESCRIPTION
Apply some Rector rules to upgrade syntax up to PHP 7.4 and drop legacy PHP support below 7.4