### PR TITLE
Set Keycloak provider's 'version' config option to null by default

### DIFF
--- a/src/DependencyInjection/Providers/KeycloakProviderConfigurator.php
+++ b/src/DependencyInjection/Providers/KeycloakProviderConfigurator.php
@@ -39,8 +39,9 @@ class KeycloakProviderConfigurator implements ProviderConfiguratorInterface
                 ->info('Optional: Encryption key, i.e. contents of key or certificate')
             ->end()
             ->scalarNode('version')
-                ->example("version: '20.0.1'")
+                ->defaultNull()
                 ->info('Optional: The keycloak version to run against')
+                ->example("version: '20.0.1'")
             ->end()
         ;
     }


### PR DESCRIPTION
Fixes #392
