### PR TITLE
drop reference to Symfony 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ class FacebookController extends AbstractController
      */
     public function connectAction(ClientRegistry $clientRegistry)
     {
-
         // will redirect to Facebook!
         return $clientRegistry
             ->getClient('facebook_main') // key used in config/packages/knpu_oauth2_client.yaml

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ class FacebookController extends AbstractController
      */
     public function connectAction(ClientRegistry $clientRegistry)
     {
-        // on Symfony 3.3 or lower, $clientRegistry = $this->get('knpu.oauth2.registry');
 
         // will redirect to Facebook!
         return $clientRegistry


### PR DESCRIPTION
Since this bundle requires at least Symfony 4, no reason to keep the documentation for Symfony 3.