### PR TITLE
drop Symfony 4.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/routing": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/http-foundation": "^4.4|^5.0|^6.0|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/routing": "^6.4|^7.0",
+        "symfony/http-foundation": "^6.4|^7.0",
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/routing": "^6.4|^7.0",
-        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+        "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+        "symfony/routing": "^5.4|^6.0|^7.0",
+        "symfony/http-foundation": "^5.4|^6.0|^7.0",
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
         "league/oauth2-facebook": "^1.1|^2.0",
-        "symfony/phpunit-bridge": "^5.3.1|^6.0|^7.0",
-        "symfony/security-guard": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0|^7.0"
+        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+        "symfony/security-guard": "^5.4",
+        "symfony/yaml": "^5.4|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": { "KnpU\\OAuth2ClientBundle\\": "src/" }


### PR DESCRIPTION
- Removes support for Symfony 4.x
- Bumps minimum supported Symfony version to `5.4`
- fixes incorrect `symfony/security-guard` constraint (version 6+ doesn't exist) 