### PR TITLE
[dx] keep tooling in one place

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "league/oauth2-facebook": "^1.1|^2.0",
         "symfony/phpunit-bridge": "^5.3.1|^6.0|^7.0",
         "symfony/security-guard": "^4.4|^5.0|^6.0|^7.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0|^7.0",
-        "phpstan/phpstan": "^1.0"
+        "symfony/yaml": "^4.4|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": { "KnpU\\OAuth2ClientBundle\\": "src/" }
@@ -37,6 +36,17 @@
         "symfony/security-guard": "For integration with Symfony's Guard Security layer"
     },
     "scripts": {
-        "test": "simple-phpunit && phpstan analyze"
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G"
     }
 }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+**/vendor
+**/composer.lock

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1"
+    }
+}


### PR DESCRIPTION
- `composer tools:run` runs `php-cs-fixer` & `phpstan`
- `composer tools:run:php-cs-fixer` run only `php-cs-fixer` (works for `phpstan` as well).
- `composer tools:upgrade` upgrades / installs all of the `tools/*`
- `composer tools:upgrade:php-cs-fixer` Upgrades / installs only `php-cs-fixer` (works for `phpstan` as well)