### PR TITLE
Fix Symfony 7.1 deprecation for Extension

### DIFF
--- a/src/DependencyInjection/KnpUOAuth2ClientExtension.php
+++ b/src/DependencyInjection/KnpUOAuth2ClientExtension.php
@@ -82,7 +82,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class KnpUOAuth2ClientExtension extends Extension
 {


### PR DESCRIPTION
Fix deprecation ([issue 447](https://github.com/knpuniversity/oauth2-client-bundle/issues/447))
_The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "KnpU\OAuth2ClientBundle\DependencyInjection\KnpUOAuth2ClientExtension"._