### PR TITLE
fix: Handle external URLs correctly in ProviderFactory (Fixes external redirect URL handling)

### DIFF
--- a/src/DependencyInjection/ProviderFactory.php
+++ b/src/DependencyInjection/ProviderFactory.php
@@ -37,8 +37,9 @@ class ProviderFactory
     public function createProvider($class, array $options, ?string $redirectUri = null, array $redirectParams = [], array $collaborators = [])
     {
         if (null !== $redirectUri) {
-            $redirectUri = $this->generator
-                ->generate($redirectUri, $redirectParams, UrlGeneratorInterface::ABSOLUTE_URL);
+            $redirectUri = filter_var($redirectUri, \FILTER_VALIDATE_URL)
+                ? $redirectUri
+                : $this->generator->generate($redirectUri, $redirectParams, UrlGeneratorInterface::ABSOLUTE_URL);
 
             $options['redirectUri'] = $redirectUri;
         }

--- a/tests/DependencyInjection/ProviderFactoryTest.php
+++ b/tests/DependencyInjection/ProviderFactoryTest.php
@@ -45,6 +45,21 @@ class ProviderFactoryTest extends TestCase
         $this->assertEquals([], $result->getCollaborators());
     }
 
+    public function testShouldCreateProviderWithExternalRedirectUrl()
+    {
+        $mockGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockGenerator->expects($this->never())->method('generate');
+
+        $testProviderFactory = new ProviderFactory($mockGenerator);
+        $externalRedirectUri = 'https://external-site.com/callback';
+        $result = $testProviderFactory->createProvider(MockProvider::class, [], $externalRedirectUri);
+
+        $this->assertInstanceOf(MockProvider::class, $result);
+        $this->assertEquals(['redirectUri' => $externalRedirectUri], $result->getOptions());
+    }
+
     private function getMockGenerator($generateReturn)
     {
         $mockGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
**Problem Description:**
In the current implementation of the createProvider method in the ProviderFactory class, any redirectUri is processed via Symfony's UrlGeneratorInterface::generate. This causes an issue when an absolute URL (external link), such as https://external-site.com/callback, is passed, since generate is only meant to work with Symfony routes. As a result, an error is thrown when trying to handle external URLs. It could be inconvenient if you work with react apps. 

**Solution:**
This feature adds a check to the createProvider method to differentiate between internal routes and external URLs. If the redirectUri is an absolute URL (determined using filter_var with FILTER_VALIDATE_URL), the URL is used directly without invoking the generate method. This prevents calling the route generator for external URLs and fixes the issue.

**Changes:**
Added a check in ProviderFactory to identify absolute URLs before attempting to generate a Symfony route.
If the redirectUri is an external URL, it is used directly without passing through the UrlGeneratorInterface.
Updated tests to cover cases where external URLs are passed.

**Tests:**
Added a new test testShouldCreateProviderWithExternalRedirectUrl, which verifies that the generate method is not called for external URLs.
Ran all existing tests to ensure no functionality was broken by this change.

