### PR TITLE
[ci] tag test as legacy due to deprecation notice

### DIFF
--- a/tests/Client/ClientRegistryTest.php
+++ b/tests/Client/ClientRegistryTest.php
@@ -17,6 +17,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ClientRegistryTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @legacy drop legacy group when no longer using guard authenticators
+     */
     public function testShouldKnowWhatServicesAreConfigured()
     {
         $mockServiceMap = [

--- a/tests/Security/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/Security/Authenticator/SocialAuthenticatorTest.php
@@ -100,7 +100,7 @@ class StubSocialAuthenticator extends SocialAuthenticator
         return $this->fetchAccessToken($client);
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
     }
     public function supports(Request $request): bool


### PR DESCRIPTION
- can drop legacy annotations once guard authenticators are no longer used

- fixes `start()` method signature in test fixture to match its respective interface