### PR TITLE
Add return types to fetchAccessToken()

### DIFF
--- a/src/Security/Authenticator/OAuth2Authenticator.php
+++ b/src/Security/Authenticator/OAuth2Authenticator.php
@@ -20,6 +20,7 @@ use KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior;
 use KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper;
 use KnpU\OAuth2ClientBundle\Security\Helper\SaveAuthFailureMessage;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 
 abstract class OAuth2Authenticator extends AbstractAuthenticator
@@ -28,6 +29,9 @@ abstract class OAuth2Authenticator extends AbstractAuthenticator
     use PreviousUrlHelper;
     use SaveAuthFailureMessage;
 
+    /**
+     * @return AccessToken
+     */
     protected function fetchAccessToken(OAuth2ClientInterface $client, array $options = [])
     {
         try {

--- a/src/Security/Authenticator/SocialAuthenticator.php
+++ b/src/Security/Authenticator/SocialAuthenticator.php
@@ -20,6 +20,7 @@ use KnpU\OAuth2ClientBundle\Security\Helper\FinishRegistrationBehavior;
 use KnpU\OAuth2ClientBundle\Security\Helper\PreviousUrlHelper;
 use KnpU\OAuth2ClientBundle\Security\Helper\SaveAuthFailureMessage;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 
@@ -29,6 +30,9 @@ abstract class SocialAuthenticator extends AbstractGuardAuthenticator
     use PreviousUrlHelper;
     use SaveAuthFailureMessage;
 
+    /**
+     * @return AccessToken
+     */
     protected function fetchAccessToken(OAuth2ClientInterface $client, array $options = [])
     {
         try {


### PR DESCRIPTION
Note that I did not use a native `: AccessToken` return type, as it would technically be a BC break (the class is not final and the method is not private)!