### PR TITLE
Update README for authenticator registration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,14 @@ security:
 +           custom_authenticators:
 +               - App\Security\MyFacebookAuthenticator
 ```
+> **IMPORTANT** If you have Symfony 6.4 or lower - you will also need to enable the new authenticator manager:
+
+```diff
+# app/config/packages/security.yaml
+security:
+    # ...  
++   enable_authenticator_manager: true
+```
 
 > **CAUTION** You *can* also inject the individual client (e.g. `FacebookClient`)
 into your authenticator instead of the `ClientRegistry`. However, this may cause


### PR DESCRIPTION
Removed instruction to enable authenticator manager in README since the option security.enable_authenticator_manager was deprecated since Symfony 6.2 and throws error in Symfony 7.3. 

See: https://github.com/scheb/2fa/issues/183